### PR TITLE
Show uncapped stat values in stacked format for mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1084,6 +1084,20 @@ header button i {
     margin: 0.1rem 0;
 }
 
+.stat-panel .stat-capped-indicator {
+    font-size: 0.7em;
+    margin-left: 0.2rem;
+    opacity: 0.8;
+    vertical-align: super;
+}
+
+.stat-panel .stat-capped-value {
+    display: block;
+    font-size: 0.7em;
+    margin-left: 0.2rem;
+    opacity: 0.8;
+}
+
 /* Advanced stats collapsible */
 .stat-panel details.advanced-stats {
     margin-top: 0.2rem;

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -266,7 +266,10 @@ const playerLoadStats = () => {
     const atkSpdRaw = Number.isFinite(player.stats.atkSpdUncapped) ? player.stats.atkSpdUncapped : player.stats.atkSpd;
     const atkSpdDisplay = player.stats.atkSpd.toFixed(2).replace(rx, "$1");
     const atkSpdRawDisplay = atkSpdRaw.toFixed(2).replace(rx, "$1");
-    playerAtkSpdElement.innerHTML = atkSpdRaw > atkSpdCap ? `${atkSpdDisplay} (${atkSpdRawDisplay})` : atkSpdDisplay;
+    const atkSpdCapped = atkSpdRaw > atkSpdCap;
+    playerAtkSpdElement.innerHTML = atkSpdCapped
+        ? `${atkSpdDisplay}<span class="stat-capped-indicator" aria-hidden="true">▲</span><span class="stat-capped-value">(${atkSpdRawDisplay})</span>`
+        : atkSpdDisplay;
     if (player.stats.atkSpd >= atkSpdCap) {
         playerAtkSpdElement.style.color = '#e30b5c';
     } else {
@@ -276,7 +279,10 @@ const playerLoadStats = () => {
     const critRateRaw = Number.isFinite(player.stats.critRateUncapped) ? player.stats.critRateUncapped : player.stats.critRate;
     const critRateDisplay = (player.stats.critRate).toFixed(2).replace(rx, "$1") + "%";
     const critRateRawDisplay = critRateRaw.toFixed(2).replace(rx, "$1") + "%";
-    playerCrateElement.innerHTML = critRateRaw > 100 ? `${critRateDisplay} (${critRateRawDisplay})` : critRateDisplay;
+    const critRateCapped = critRateRaw > 100;
+    playerCrateElement.innerHTML = critRateCapped
+        ? `${critRateDisplay}<span class="stat-capped-indicator" aria-hidden="true">▲</span><span class="stat-capped-value">(${critRateRawDisplay})</span>`
+        : critRateDisplay;
     if (player.stats.critRate >= 100) {
         playerCrateElement.style.color = '#e30b5c';
     } else {


### PR DESCRIPTION
### Motivation
- Hover-based tooltips for uncapped stat values are not accessible on touch devices, causing users on Android and other phones to miss the full numbers. 
- Keep stat rows narrow while still exposing uncapped values so the stat panel remains readable on small screens.

### Description
- Replace hover/tooltips with a stacked inline display for uncapped values in `assets/js/player.js` for `atkSpd` and `critRate`, adding a small indicator glyph and a visible secondary line with the uncapped value. 
- Add `aria-hidden="true"` to the indicator glyph so assistive tech ignores it, and remove reliance on the `title` tooltip. 
- Add `.stat-capped-value` CSS rules and tweak `.stat-capped-indicator` in `assets/css/style.css` to style the stacked uncapped value and keep rows compact on mobile. 
- Modified files: `assets/js/player.js`, `assets/css/style.css`.

### Testing
- Served the site with `python3 -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/` and capture a screenshot; the script completed successfully and produced `artifacts/stat-panel-stacked.png`.
- No unit tests exist for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbabf6f0483268f62fea6151f1eae)