### PR TITLE
Add Curse Room feature

### DIFF
--- a/assets/js/combat.js
+++ b/assets/js/combat.js
@@ -1015,6 +1015,25 @@ const handleClaimButtonClick = () => {
         addDungeonLog(t('moved-to-next-room'));
     }
 
+    // Curse room rewards and cleanup
+    if (enemy.condition === 'curse' && dungeon.inCurseRoom) {
+        const floorBonus = dungeon.progress.floor;
+        const bonusXp = floorBonus * 100;
+        const bonusGold = floorBonus * 50;
+        const oldCurse = player.selectedCurseLevel || 0;
+        // Apply curse reduction if applicable
+        if (dungeon.curseRoomCurseReduction > 0 && oldCurse > 0) {
+            const newCurse = Math.max(0, oldCurse - dungeon.curseRoomCurseReduction);
+            player.selectedCurseLevel = newCurse;
+            addDungeonLog(t('curse-room-curse-reduced', { old: Math.round(oldCurse), new: Math.round(newCurse) }));
+        }
+        // Bonus rewards message
+        addDungeonLog(t('curse-room-victory', { xp: nFormatter(bonusXp), gold: nFormatter(bonusGold), loot: '10%' }));
+        // Clean up curse room state
+        dungeon.inCurseRoom = false;
+        dungeon.curseRoomCurseReduction = 0;
+    }
+
     let dimDungeon = document.querySelector('#dungeon-main');
     dimDungeon.style.filter = "brightness(100%)";
     bgmDungeon.play();

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -830,8 +830,24 @@ const curseRoomEvent = () => {
         // Set curse room flags for enhanced combat
         dungeon.inCurseRoom = true;
         dungeon.curseRoomCurseReduction = curseReduction;
-        // Trigger enhanced enemy encounter
-        enemyEncounter(true); // true = enhanced
+        // Generate enhanced enemy and start combat
+        dungeon.status.event = false;
+        currentEvent = null;
+        generateRandomEnemy();
+        choices = `
+            <div class="decision-panel">
+                <button id="choice1" data-i18n="engage">${t('engage')}</button>
+                <button id="choice2" data-i18n="flee">${t('flee')}</button>
+            </div>`;
+        enemy.name = getDisplayEnemyName(enemy.id);
+        addDungeonLog(t('encountered-enemy', { enemy: getDisplayEnemyName(enemy.id, enemy.name) }), choices);
+        document.querySelector("#choice1").onclick = function () {
+            engageBattle();
+        };
+        document.querySelector("#choice2").onclick = function () {
+            fleeBattle();
+        };
+        autoConfirm();
     };
     document.querySelector("#choice2").onclick = function () {
         dungeon.action = 0;

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -810,7 +810,7 @@ const nothingEvent = () => {
 // Curse Room Event
 const curseRoomEvent = () => {
     dungeon.status.event = true;
-    let curseLevel = dungeon.curse || 0;
+    let curseLevel = player.selectedCurseLevel || 0;
     let curseReduction = 0;
     // Chance to reduce curse: 20% base + 5% per curse level
     if (curseLevel > 0 && randomizeNum(1, 100) <= (20 + curseLevel * 5)) {

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -96,6 +96,9 @@ let dungeon = {
         stairsIgnored: false,
     },
     story: createDefaultDungeonStory(),
+    // Curse room state
+    inCurseRoom: false,
+    curseRoomCurseReduction: 0,
 };
 
 const ensureRoomEventsState = () => {
@@ -427,6 +430,13 @@ const dungeonEvent = () => {
         if (dungeon.story.monarchUnlocked && !dungeon.story.monarchSeen) {
             eventTypes.push("monarch", "monarch", "monarch");
         }
+        // Curse rooms appear from floor 5+, chance increases with floor
+        if (dungeon.progress.floor >= 5) {
+            let curseChance = Math.min(dungeon.progress.floor - 4, 10); // 1% at floor 5, up to 10% at floor 14+
+            if (randomizeNum(1, 100) <= curseChance) {
+                eventTypes.push("curse");
+            }
+        }
         if ( dungeon.progress.floor < 5 && dungeon.progress.room === 1 && player.equipped.length === 6 && !dungeon.roomEvents.stairsIgnored) {
         	eventTypes.push("stairs");        	
         	eventTypes.push("stairs");
@@ -534,6 +544,9 @@ const dungeonEvent = () => {
                 break;
             case "nothing":
                 nothingEvent();
+                break;
+            case "curse":
+                curseRoomEvent();
                 break;
             case "stairs":
                 dungeon.status.event = true;
@@ -723,15 +736,20 @@ const fleeBattle = () => {
     let eventRoll = randomizeNum(1, 10);
     if (eventRoll <= 9) {
         sfxConfirm.play();
-    addDungeonLog(t('flee-success'));
+        addDungeonLog(t('flee-success'));
         player.inCombat = false;
         dungeon.status.event = false;
+        // Clean up curse room state if fleeing from one
+        if (dungeon.inCurseRoom) {
+            dungeon.inCurseRoom = false;
+            dungeon.curseRoomCurseReduction = 0;
+        }
     } else {
-    addDungeonLog(t('flee-failure'));
+        addDungeonLog(t('flee-failure'));
         showCombatInfo();
-    addCombatLog(t('encountered-enemy', { enemy: getDisplayEnemyName(enemy.id, enemy.name) }));
+        addCombatLog(t('encountered-enemy', { enemy: getDisplayEnemyName(enemy.id, enemy.name) }));
         startCombat(bgmBattleMain);
-    addCombatLog(t('flee-failure'));
+        addCombatLog(t('flee-failure'));
     }
 }
 
@@ -788,6 +806,39 @@ const nothingEvent = () => {
     addDungeonLog(t('nothing-here'));
     }
 }
+
+// Curse Room Event
+const curseRoomEvent = () => {
+    dungeon.status.event = true;
+    let curseLevel = dungeon.curse || 0;
+    let curseReduction = 0;
+    // Chance to reduce curse: 20% base + 5% per curse level
+    if (curseLevel > 0 && randomizeNum(1, 100) <= (20 + curseLevel * 5)) {
+        curseReduction = 1;
+    }
+    let choices = `
+        <div class="decision-panel">
+            <button id="choice1" data-i18n="curse-room-enter">${t('curse-room-enter')}</button>
+            <button id="choice2" data-i18n="curse-room-ignore">${t('curse-room-ignore')}</button>
+        </div>`;
+    addDungeonLog(t('curse-room-discovered'));
+    addDungeonLog(t('curse-room-description', { level: curseLevel }), choices);
+    document.querySelector("#choice1").onclick = function () {
+        sfxConfirm.play();
+        dungeon.status.event = false;
+        currentEvent = null;
+        // Set curse room flags for enhanced combat
+        dungeon.inCurseRoom = true;
+        dungeon.curseRoomCurseReduction = curseReduction;
+        // Trigger enhanced enemy encounter
+        enemyEncounter(true); // true = enhanced
+    };
+    document.querySelector("#choice2").onclick = function () {
+        dungeon.action = 0;
+        ignoreEvent();
+    };
+    autoDecline();
+};
 
 // Random stat buff
 const statBlessing = () => {

--- a/assets/js/enemy.js
+++ b/assets/js/enemy.js
@@ -279,6 +279,17 @@ const setEnemyStats = (type, condition) => {
         enemy.stats.critDmg = enemy.stats.critDmg * 1.2;
     }
 
+    // Stat multiplier for curse rooms
+    if (dungeon.inCurseRoom) {
+        enemy.stats.hpMax = enemy.stats.hpMax * 2;
+        enemy.stats.atk = enemy.stats.atk * 1.5;
+        enemy.stats.def = enemy.stats.def * 1.3;
+        enemy.stats.critRate = enemy.stats.critRate * 1.2;
+        enemy.stats.critDmg = enemy.stats.critDmg * 1.2;
+        // Mark enemy as curse enemy for bonus rewards
+        enemy.condition = 'curse';
+    }
+
     // Apply stat multipliers for every stat
     let floorMultiplier = (dungeon.progress.floor / 3);
     if (floorMultiplier < 1) {

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -449,5 +449,13 @@
   ,"descend": "Descend"
   ,"descended-to-floor": "You descended to floor {floor}."
   ,"found-stairs": "You found stairs leading deeper into the dungeon."
+  ,"curse-room-discovered": "<span class='Epic'>⚠️ A curse shrine pulses in the shadows...</span>"
+  ,"curse-room-description": "<span class='Epic'>Curse Level {level}:</span> Dangerous enemies ahead, but glory comes with risk."
+  ,"curse-room-enter": "Enter the Curse Room"
+  ,"curse-room-ignore": "Leave"
+  ,"curse-room-entered": "You entered the cursed chamber. Enemies are strengthened!"
+  ,"curse-room-victory": "<span class='Legendary'>🏆 Victory! The curse recedes... +{xp} XP, +{gold} Gold, +{loot} Loot Boost!</span>"
+  ,"curse-room-loot-bonus": "<span class='Legendary'>Bonus Loot: {item}!</span>"
+  ,"curse-room-curse-reduced": "<span class='Epic'>Your curse has weakened! ({old} → {new})</span>"
 
 }


### PR DESCRIPTION
- New curse room event appears from floor 5+ (chance increases with floor)
- Curse rooms have enhanced enemies (2x HP, 1.5x ATK, 1.3x DEF)
- 20%+ chance per curse level to reduce player's curse after victory
- Bonus XP and gold rewards for completing curse rooms
- Fleeing from curse rooms resets the curse room state