### PR TITLE
feat: translate enemy type badges in all languages

### DIFF
--- a/assets/js/combat.js
+++ b/assets/js/combat.js
@@ -1550,7 +1550,7 @@ const showCombatInfo = () => {
     document.querySelector('#combatPanel').innerHTML = `
     <div class="content">
         <div class="battle-info-panel center" id="enemyPanel">
-            <p>${enemy.name} Lv.${enemy.lvl} <span class="enemy-type-badge enemy-type-${enemy.type.toLowerCase()}">${enemy.type}</span></p>
+            <p>${enemy.name} Lv.${enemy.lvl} <span class="enemy-type-badge enemy-type-${enemy.type.toLowerCase()}">${t('enemy-type-' + enemy.type.toLowerCase())}</span></p>
             <div class="battle-bar empty-bar hp bb-hp">
                 <div class="battle-bar dmg bb-hp" id="enemy-hp-dmg"></div>
                 <div class="battle-bar current bb-hp" id="enemy-hp-battle">

--- a/assets/locales/ar.json
+++ b/assets/locales/ar.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "عدواني",
+  "enemy-type-defensive": "دفاعي",
+  "enemy-type-balanced": "متوازن",
+  "enemy-type-quick": "سريع",
+  "enemy-type-lethal": "قاتل"
 }

--- a/assets/locales/de.json
+++ b/assets/locales/de.json
@@ -328,39 +328,38 @@
   "story-beat-floor-20": "Irgendwo tiefer unten erzittert eine versiegelte Kammer. Der Dungeon-Monarch erwacht.",
   "resting-bonus-focus": "<span style='color: #FFD700;'>🧠 Du fühlst dich geistig fokussiert! (+10% ATK.GES bis zur nächsten Etage)</span>",
   "resting-bonus-vitality": "<span style='color: #FF5722;'>💪 Du fühlst dich körperlich energiegeladen! (+15% ATK bis zur nächsten Etage)</span>",
-  "resting-bonus-serenity": "<span style='color: #2196F3;'>🛡️ Du fühlst inneren Frieden! (+12% DEF bis zur nächsten Etage)</span>"
-  ,"pray": "Beten"
-  ,"guardian-blocking-way": "Etagenwächter {enemy} versperrt dir den Weg."
-  ,"you-died-hardcore": "Du bist gestorben! <span class='Heirloom'>Hardcore-Modus:</span> Du verlierst dein gesamtes <b>Inventar</b> und <b>Gold</b>."
-  ,"you-died-softcore": "Du bist gestorben! Du behältst dein <b>Inventar</b> und dein <b>Gold</b>."
-  ,"enemy-defeated-reward": "{enemy} besiegt: +{exp} EXP, <i class='fas fa-coins' style='color: #FFD700;'></i>{gold} Gold ({time})"
-  ,"crit-damage": "krit Schaden"
-  ,"damage": "Schaden"
-  ,"dodged-attack-enemy": "{enemy} ist dem Angriff ausgewichen!"
-  ,"dodged-attack-companion": "{enemy} ist dem Angriff von {companion} ausgewichen!"
-  ,"dodged-attack-player": "{player} ist dem Angriff ausgewichen!"
-  ,"scout-dodged-attack": "{player} rollt sich aus dem Weg!"
-  ,"special-ability-scout-dodge": "{player} bereitet sich darauf vor, dem nächsten Angriff auszuweichen!"
-  ,"player-attack-hit": "{player} verursacht {value} {type} an {enemy}{lifesteal}."
-  ,"player-vamp-heal": ", und heilte {value} HP durch Vampirismus"
-  ,"companion-attack-hit": "{companion} verursacht {value} {type} an {enemy}."
-  ,"enemy-attack-hit": "{enemy} verursacht {value} {type} an {player}{lifesteal}."
-  ,"enemy-vamp-heal": ", und heilte {value} HP durch Vampirismus"
-  ,"special-ability-attack-hit": "{player} entfesselt eine Spezialfähigkeit für {value} {type}{lifesteal}!"
-  ,"special-ability-heal": "{player} nutzt eine Spezialfähigkeit und heilt {hp} HP!"
-  ,"special-ability-companion-boost": "{player} stärkt {companion}! +50% ATK/APS (5 Sek.)."
-  ,"special-ability-no-companion": "Du benötigst einen aktiven Begleiter, um diese Fähigkeit zu nutzen."
-  ,"claim": "Beanspruchen"
-  ,"start-new-run": "Neuen Lauf starten"
-  ,"attack": "Angreifen"
-  ,"special-ability": "Spezialfähigkeit"
-  ,"cooling": "Abkühlung..."
-  ,"you-leveled-up": "Du bist aufgestiegen! (Lv.{previousLvl} > Lv.{newLvl})"
-  ,"level-up": "Level Up!"
-  ,"remaining": "Verbleibend: {count}"
-  ,"reroll-button": "Neu würfeln {remaining}/{total}"
-
-  ,"equipment-names": {
+  "resting-bonus-serenity": "<span style='color: #2196F3;'>🛡️ Du fühlst inneren Frieden! (+12% DEF bis zur nächsten Etage)</span>",
+  "pray": "Beten",
+  "guardian-blocking-way": "Etagenwächter {enemy} versperrt dir den Weg.",
+  "you-died-hardcore": "Du bist gestorben! <span class='Heirloom'>Hardcore-Modus:</span> Du verlierst dein gesamtes <b>Inventar</b> und <b>Gold</b>.",
+  "you-died-softcore": "Du bist gestorben! Du behältst dein <b>Inventar</b> und dein <b>Gold</b>.",
+  "enemy-defeated-reward": "{enemy} besiegt: +{exp} EXP, <i class='fas fa-coins' style='color: #FFD700;'></i>{gold} Gold ({time})",
+  "crit-damage": "krit Schaden",
+  "damage": "Schaden",
+  "dodged-attack-enemy": "{enemy} ist dem Angriff ausgewichen!",
+  "dodged-attack-companion": "{enemy} ist dem Angriff von {companion} ausgewichen!",
+  "dodged-attack-player": "{player} ist dem Angriff ausgewichen!",
+  "scout-dodged-attack": "{player} rollt sich aus dem Weg!",
+  "special-ability-scout-dodge": "{player} bereitet sich darauf vor, dem nächsten Angriff auszuweichen!",
+  "player-attack-hit": "{player} verursacht {value} {type} an {enemy}{lifesteal}.",
+  "player-vamp-heal": ", und heilte {value} HP durch Vampirismus",
+  "companion-attack-hit": "{companion} verursacht {value} {type} an {enemy}.",
+  "enemy-attack-hit": "{enemy} verursacht {value} {type} an {player}{lifesteal}.",
+  "enemy-vamp-heal": ", und heilte {value} HP durch Vampirismus",
+  "special-ability-attack-hit": "{player} entfesselt eine Spezialfähigkeit für {value} {type}{lifesteal}!",
+  "special-ability-heal": "{player} nutzt eine Spezialfähigkeit und heilt {hp} HP!",
+  "special-ability-companion-boost": "{player} stärkt {companion}! +50% ATK/APS (5 Sek.).",
+  "special-ability-no-companion": "Du benötigst einen aktiven Begleiter, um diese Fähigkeit zu nutzen.",
+  "claim": "Beanspruchen",
+  "start-new-run": "Neuen Lauf starten",
+  "attack": "Angreifen",
+  "special-ability": "Spezialfähigkeit",
+  "cooling": "Abkühlung...",
+  "you-leveled-up": "Du bist aufgestiegen! (Lv.{previousLvl} > Lv.{newLvl})",
+  "level-up": "Level Up!",
+  "remaining": "Verbleibend: {count}",
+  "reroll-button": "Neu würfeln {remaining}/{total}",
+  "equipment-names": {
     "sword": "Schwert",
     "axe": "Axt",
     "hammer": "Hammer",
@@ -378,9 +377,8 @@
     "mask": "Maske",
     "boots": "Stiefel",
     "charm": "Talisman"
-  }
-
-  ,"enemy-names": {
+  },
+  "enemy-names": {
     "goblin": "Goblin",
     "goblin-rogue": "Goblin Schurke",
     "goblin-mage": "Goblin Magier",
@@ -432,9 +430,8 @@
     "thanatos": "Thanatos",
     "darkness-angel-reaper": "Dunkelheitsengel Schnitter",
     "zalaras-dragon-emperor": "Zalaras, der Drachenkaiser"
-  }
-
-  ,"equipment-genders": {
+  },
+  "equipment-genders": {
     "sword": "n",
     "axe": "f",
     "hammer": "m",
@@ -451,22 +448,51 @@
     "horned-helm": "m",
     "mask": "f",
     "boots": "m"
-  }
-
-  ,"level-up-option": {
-    "hp": { "title": "HP UP", "desc": "Erhöhe Bonus-HP um {value}%." },
-    "atk": { "title": "ATK UP", "desc": "Erhöhe Bonus-ATK um {value}%." },
-    "def": { "title": "DEF UP", "desc": "Erhöhe Bonus-DEF um {value}%." },
-    "atkSpd": { "title": "ATK.GES UP", "desc": "Erhöhe Bonus-ATK.GES um {value}%." },
-    "vamp": { "title": "VAMP UP", "desc": "Erhöhe Bonus-VAMP um {value}%." },
-    "critRate": { "title": "C.RATE UP", "desc": "Erhöhe Bonus-C.RATE um {value}%." },
-    "critDmg": { "title": "C.DMG UP", "desc": "Erhöhe Bonus-C.DMG um {value}%." },
-    "dodge": { "title": "DODGE UP", "desc": "Erhöhe Bonus-DODGE um {value}%." },
-    "luck": { "title": "LUCK UP", "desc": "Erhöhe Bonus-LUCK um {value}%." }
-  }
-
-  ,"descend": "Hinabsteigen"
-  ,"descended-to-floor": "Du bist zur Ebene {floor} hinabgestiegen."
-  ,"found-stairs": "Du hast eine Treppe gefunden, die tiefer in den Dungeon führt."
-
+  },
+  "level-up-option": {
+    "hp": {
+      "title": "HP UP",
+      "desc": "Erhöhe Bonus-HP um {value}%."
+    },
+    "atk": {
+      "title": "ATK UP",
+      "desc": "Erhöhe Bonus-ATK um {value}%."
+    },
+    "def": {
+      "title": "DEF UP",
+      "desc": "Erhöhe Bonus-DEF um {value}%."
+    },
+    "atkSpd": {
+      "title": "ATK.GES UP",
+      "desc": "Erhöhe Bonus-ATK.GES um {value}%."
+    },
+    "vamp": {
+      "title": "VAMP UP",
+      "desc": "Erhöhe Bonus-VAMP um {value}%."
+    },
+    "critRate": {
+      "title": "C.RATE UP",
+      "desc": "Erhöhe Bonus-C.RATE um {value}%."
+    },
+    "critDmg": {
+      "title": "C.DMG UP",
+      "desc": "Erhöhe Bonus-C.DMG um {value}%."
+    },
+    "dodge": {
+      "title": "DODGE UP",
+      "desc": "Erhöhe Bonus-DODGE um {value}%."
+    },
+    "luck": {
+      "title": "LUCK UP",
+      "desc": "Erhöhe Bonus-LUCK um {value}%."
+    }
+  },
+  "descend": "Hinabsteigen",
+  "descended-to-floor": "Du bist zur Ebene {floor} hinabgestiegen.",
+  "found-stairs": "Du hast eine Treppe gefunden, die tiefer in den Dungeon führt.",
+  "enemy-type-offensive": "Offensiv",
+  "enemy-type-defensive": "Defensiv",
+  "enemy-type-balanced": "Ausgewogen",
+  "enemy-type-quick": "Schnell",
+  "enemy-type-lethal": "Tödlich"
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -188,7 +188,7 @@
   "companions": "Companions",
   "the-forge": "The Forge",
   "value": "Value",
-  "equipped": "Equipped",  
+  "equipped": "Equipped",
   "forged-equipment": "Forged Equipment",
   "combine-three-items-of-the-same-tier-and-rarity-to-forge-one-of-the-next-rarity": "Combine three items of the same tier and rarity to forge one of the next rarity!",
   "material-1": "Material 1",
@@ -328,39 +328,38 @@
   "story-beat-floor-20": "A sealed chamber shudders somewhere below. The Dungeon Monarch is waking.",
   "resting-bonus-focus": "<span style='color: #FFD700;'>🧠 You feel mentally focused! (+10% ATK.SPD until next floor)</span>",
   "resting-bonus-vitality": "<span style='color: #FF5722;'>💪 You feel physically energized! (+15% ATK until next floor)</span>",
-  "resting-bonus-serenity": "<span style='color: #2196F3;'>🛡️ You feel inner peace! (+12% DEF until next floor)</span>"
-  ,"pray": "Pray"
-  ,"guardian-blocking-way": "Floor Guardian {enemy} is blocking your way."
-    ,"you-died-hardcore": "You died! <span class='Heirloom'>Hardcore mode:</span> you lose all <b>inventory</b> and <b>gold</b>."
-    ,"you-died-softcore": "You died! You keep your <b>inventory</b> and <b>gold</b>."
-    ,"enemy-defeated-reward": "{enemy} defeated: +{exp} exp, <i class='fas fa-coins' style='color: #FFD700;'></i>{gold} gold ({time})"
-    ,"crit-damage": "crit damage"
-    ,"damage": "damage"
-    ,"dodged-attack-enemy": "{enemy} dodged the attack!"
-    ,"dodged-attack-companion": "{enemy} dodged {companion}'s attack!"
-    ,"dodged-attack-player": "{player} dodged the attack!"
-    ,"scout-dodged-attack": "{player} tumbles out of the way!"
-    ,"special-ability-scout-dodge": "{player} prepares to tumble away from the next attack!"
-    ,"player-attack-hit": "{player} dealt {value} {type} to {enemy}{lifesteal}."
-    ,"player-vamp-heal": ", and healed {value} HP from vampirism"
-    ,"companion-attack-hit": "{companion} dealt {value} {type} to {enemy}."
-    ,"enemy-attack-hit": "{enemy} dealt {value} {type} to {player}{lifesteal}."
-    ,"enemy-vamp-heal": ", and healed {value} HP from vampirism"
-    ,"special-ability-attack-hit": "{player} unleashed a special ability for {value} {type}{lifesteal}!"
-    ,"special-ability-heal": "{player} used a special ability and healed {hp} HP!"
-    ,"special-ability-companion-boost": "{player} boosted {companion}! +50% ATK/APS for 5s."
-    ,"special-ability-no-companion": "You need an active companion to use this ability."
-    ,"claim": "Claim"
-    ,"start-new-run": "Start new Run"
-    ,"attack": "Attack"
-  ,"special-ability": "Special Ability"
-  ,"cooling": "Cooling..."
-  ,"you-leveled-up": "You leveled up! (Lv.{previousLvl} > Lv.{newLvl})"
-  ,"level-up": "Level Up!"
-  ,"remaining": "Remaining: {count}"
-  ,"reroll-button": "Reroll {remaining}/{total}"
-
-  ,"equipment-names": {
+  "resting-bonus-serenity": "<span style='color: #2196F3;'>🛡️ You feel inner peace! (+12% DEF until next floor)</span>",
+  "pray": "Pray",
+  "guardian-blocking-way": "Floor Guardian {enemy} is blocking your way.",
+  "you-died-hardcore": "You died! <span class='Heirloom'>Hardcore mode:</span> you lose all <b>inventory</b> and <b>gold</b>.",
+  "you-died-softcore": "You died! You keep your <b>inventory</b> and <b>gold</b>.",
+  "enemy-defeated-reward": "{enemy} defeated: +{exp} exp, <i class='fas fa-coins' style='color: #FFD700;'></i>{gold} gold ({time})",
+  "crit-damage": "crit damage",
+  "damage": "damage",
+  "dodged-attack-enemy": "{enemy} dodged the attack!",
+  "dodged-attack-companion": "{enemy} dodged {companion}'s attack!",
+  "dodged-attack-player": "{player} dodged the attack!",
+  "scout-dodged-attack": "{player} tumbles out of the way!",
+  "special-ability-scout-dodge": "{player} prepares to tumble away from the next attack!",
+  "player-attack-hit": "{player} dealt {value} {type} to {enemy}{lifesteal}.",
+  "player-vamp-heal": ", and healed {value} HP from vampirism",
+  "companion-attack-hit": "{companion} dealt {value} {type} to {enemy}.",
+  "enemy-attack-hit": "{enemy} dealt {value} {type} to {player}{lifesteal}.",
+  "enemy-vamp-heal": ", and healed {value} HP from vampirism",
+  "special-ability-attack-hit": "{player} unleashed a special ability for {value} {type}{lifesteal}!",
+  "special-ability-heal": "{player} used a special ability and healed {hp} HP!",
+  "special-ability-companion-boost": "{player} boosted {companion}! +50% ATK/APS for 5s.",
+  "special-ability-no-companion": "You need an active companion to use this ability.",
+  "claim": "Claim",
+  "start-new-run": "Start new Run",
+  "attack": "Attack",
+  "special-ability": "Special Ability",
+  "cooling": "Cooling...",
+  "you-leveled-up": "You leveled up! (Lv.{previousLvl} > Lv.{newLvl})",
+  "level-up": "Level Up!",
+  "remaining": "Remaining: {count}",
+  "reroll-button": "Reroll {remaining}/{total}",
+  "equipment-names": {
     "sword": "Sword",
     "axe": "Axe",
     "hammer": "Hammer",
@@ -378,9 +377,8 @@
     "mask": "Mask",
     "boots": "Boots",
     "charm": "Charm"
-  }
-
-  ,"enemy-names": {
+  },
+  "enemy-names": {
     "goblin": "Goblin",
     "goblin-rogue": "Goblin Rogue",
     "goblin-mage": "Goblin Mage",
@@ -397,7 +395,7 @@
     "orc-archer": "Orc Archer",
     "orc-mage": "Orc Mage",
     "spider": "Spider",
-  "red-spider": "Red Spider",
+    "red-spider": "Red Spider",
     "green-spider": "Green Spider",
     "skeleton-archer": "Skeleton Archer",
     "skeleton-swordsmaster": "Skeleton Swordsmaster",
@@ -432,22 +430,51 @@
     "thanatos": "Thanatos",
     "darkness-angel-reaper": "Darkness Angel Reaper",
     "zalaras-dragon-emperor": "Zalaras, the Dragon Emperor"
-  }
-
-  ,"level-up-option": {
-    "hp": { "title": "HP UP", "desc": "Increase bonus HP by {value}%." },
-    "atk": { "title": "ATK UP", "desc": "Increase bonus ATK by {value}%." },
-    "def": { "title": "DEF UP", "desc": "Increase bonus DEF by {value}%." },
-    "atkSpd": { "title": "ATK.SPD UP", "desc": "Increase bonus ATK.SPD by {value}%." },
-    "vamp": { "title": "VAMP UP", "desc": "Increase bonus VAMP by {value}%." },
-    "critRate": { "title": "C.RATE UP", "desc": "Increase bonus C.RATE by {value}%." },
-    "critDmg": { "title": "C.DMG UP", "desc": "Increase bonus C.DMG by {value}%." },
-    "dodge": { "title": "DODGE UP", "desc": "Increase bonus DODGE by {value}%." },
-    "luck": { "title": "LUCK UP", "desc": "Increase bonus LUCK by {value}%." }
-  }
-
-  ,"descend": "Descend"
-  ,"descended-to-floor": "You descended to floor {floor}."
-  ,"found-stairs": "You found stairs leading deeper into the dungeon."
-
+  },
+  "level-up-option": {
+    "hp": {
+      "title": "HP UP",
+      "desc": "Increase bonus HP by {value}%."
+    },
+    "atk": {
+      "title": "ATK UP",
+      "desc": "Increase bonus ATK by {value}%."
+    },
+    "def": {
+      "title": "DEF UP",
+      "desc": "Increase bonus DEF by {value}%."
+    },
+    "atkSpd": {
+      "title": "ATK.SPD UP",
+      "desc": "Increase bonus ATK.SPD by {value}%."
+    },
+    "vamp": {
+      "title": "VAMP UP",
+      "desc": "Increase bonus VAMP by {value}%."
+    },
+    "critRate": {
+      "title": "C.RATE UP",
+      "desc": "Increase bonus C.RATE by {value}%."
+    },
+    "critDmg": {
+      "title": "C.DMG UP",
+      "desc": "Increase bonus C.DMG by {value}%."
+    },
+    "dodge": {
+      "title": "DODGE UP",
+      "desc": "Increase bonus DODGE by {value}%."
+    },
+    "luck": {
+      "title": "LUCK UP",
+      "desc": "Increase bonus LUCK by {value}%."
+    }
+  },
+  "descend": "Descend",
+  "descended-to-floor": "You descended to floor {floor}.",
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "Offensive",
+  "enemy-type-defensive": "Defensive",
+  "enemy-type-balanced": "Balanced",
+  "enemy-type-quick": "Quick",
+  "enemy-type-lethal": "Lethal"
 }

--- a/assets/locales/es.json
+++ b/assets/locales/es.json
@@ -359,7 +359,6 @@
   "level-up": "¡Nivel aumentado!",
   "remaining": "Restante: {count}",
   "reroll-button": "Volver a tirar {remaining}/{total}",
-
   "equipment-names": {
     "sword": "Espada",
     "axe": "Hacha",
@@ -379,7 +378,6 @@
     "boots": "Botas",
     "charm": "Amuleto"
   },
-
   "enemy-names": {
     "goblin": "Goblin",
     "goblin-rogue": "Goblin pícaro",
@@ -433,20 +431,50 @@
     "darkness-angel-reaper": "Ángel de la oscuridad segador",
     "zalaras-dragon-emperor": "Zalaras, el emperador dragón"
   },
-
   "level-up-option": {
-    "hp": { "title": "HP +", "desc": "Incrementa el HP adicional en {value}%." },
-    "atk": { "title": "ATQ +", "desc": "Incrementa el ATQ adicional en {value}%." },
-    "def": { "title": "DEF +", "desc": "Incrementa la DEF adicional en {value}%." },
-    "atkSpd": { "title": "VEL.ATQ +", "desc": "Incrementa la VEL.ATQ adicional en {value}%." },
-    "vamp": { "title": "VAMP +", "desc": "Incrementa el VAMP adicional en {value}%." },
-    "critRate": { "title": "T.CRIT +", "desc": "Incrementa la T.CRIT adicional en {value}%." },
-    "critDmg": { "title": "D.CRIT +", "desc": "Incrementa el D.CRIT adicional en {value}%." },
-    "dodge": { "title": "ESQ +", "desc": "Incrementa la ESQ adicional en {value}%." },
-    "luck": { "title": "SUERTE +", "desc": "Incrementa la SUERTE adicional en {value}%." }
+    "hp": {
+      "title": "HP +",
+      "desc": "Incrementa el HP adicional en {value}%."
+    },
+    "atk": {
+      "title": "ATQ +",
+      "desc": "Incrementa el ATQ adicional en {value}%."
+    },
+    "def": {
+      "title": "DEF +",
+      "desc": "Incrementa la DEF adicional en {value}%."
+    },
+    "atkSpd": {
+      "title": "VEL.ATQ +",
+      "desc": "Incrementa la VEL.ATQ adicional en {value}%."
+    },
+    "vamp": {
+      "title": "VAMP +",
+      "desc": "Incrementa el VAMP adicional en {value}%."
+    },
+    "critRate": {
+      "title": "T.CRIT +",
+      "desc": "Incrementa la T.CRIT adicional en {value}%."
+    },
+    "critDmg": {
+      "title": "D.CRIT +",
+      "desc": "Incrementa el D.CRIT adicional en {value}%."
+    },
+    "dodge": {
+      "title": "ESQ +",
+      "desc": "Incrementa la ESQ adicional en {value}%."
+    },
+    "luck": {
+      "title": "SUERTE +",
+      "desc": "Incrementa la SUERTE adicional en {value}%."
+    }
   },
-
   "descend": "Descender",
   "descended-to-floor": "Descendiste al piso {floor}.",
-  "found-stairs": "Encontraste unas escaleras que descienden más profundo en la mazmorra."
+  "found-stairs": "Encontraste unas escaleras que descienden más profundo en la mazmorra.",
+  "enemy-type-offensive": "Ofensivo",
+  "enemy-type-defensive": "Defensivo",
+  "enemy-type-balanced": "Equilibrado",
+  "enemy-type-quick": "Rápido",
+  "enemy-type-lethal": "Letal"
 }

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "Offensif",
+  "enemy-type-defensive": "Défensif",
+  "enemy-type-balanced": "Équilibré",
+  "enemy-type-quick": "Rapide",
+  "enemy-type-lethal": "Létal"
 }

--- a/assets/locales/hi.json
+++ b/assets/locales/hi.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "आक्रामक",
+  "enemy-type-defensive": "रक्षात्मक",
+  "enemy-type-balanced": "संतुलित",
+  "enemy-type-quick": "तेज़",
+  "enemy-type-lethal": "घातक"
 }

--- a/assets/locales/id.json
+++ b/assets/locales/id.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "Ofensif",
+  "enemy-type-defensive": "Defensif",
+  "enemy-type-balanced": "Seimbang",
+  "enemy-type-quick": "Cepat",
+  "enemy-type-lethal": "Mematikan"
 }

--- a/assets/locales/it.json
+++ b/assets/locales/it.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "Offensivo",
+  "enemy-type-defensive": "Difensivo",
+  "enemy-type-balanced": "Bilanciato",
+  "enemy-type-quick": "Veloce",
+  "enemy-type-lethal": "Letale"
 }

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -328,39 +328,38 @@
   "story-beat-floor-20": "さらに下で封印された間が震える。ダンジョンモナークが目覚めつつある。",
   "resting-bonus-focus": "<span style='color: #FFD700;'>🧠 精神が集中した！ (次の階までATK.SPD+10%)</span>",
   "resting-bonus-vitality": "<span style='color: #FF5722;'>💪 体が活力に満ちた！ (次の階までATK+15%)</span>",
-  "resting-bonus-serenity": "<span style='color: #2196F3;'>🛡️ 心が安らいだ！ (次の階までDEF+12%)</span>"
-  ,"pray": "祈る"
-  ,"guardian-blocking-way": "階のガーディアン{enemy}が行く手を阻んでいる。"
-  ,"you-died-hardcore": "あなたは死んだ！ <span class='Heirloom'>ハードコアモード:</span> すべての<b>インベントリ</b>と<b>ゴールド</b>を失う。"
-  ,"you-died-softcore": "あなたは死んだ！ <b>インベントリ</b>と<b>ゴールド</b>は保持される。"
-  ,"enemy-defeated-reward": "{enemy}を倒した: +{exp} exp, <i class='fas fa-coins' style='color: #FFD700;'></i>{gold} ゴールド ({time})"
-  ,"crit-damage": "クリティカルダメージ"
-  ,"damage": "ダメージ"
-  ,"dodged-attack-enemy": "{enemy}は攻撃を回避した！"
-  ,"dodged-attack-companion": "{enemy}は{companion}の攻撃を回避した！"
-  ,"dodged-attack-player": "{player}は攻撃を回避した！"
-  ,"scout-dodged-attack": "{player}は身を翻して攻撃をかわした！"
-  ,"special-ability-scout-dodge": "{player}は次の攻撃を避ける準備をしている！"
-  ,"player-attack-hit": "{player}は{enemy}に{value}{type}を与え{lifesteal}。"
-  ,"player-vamp-heal": "、吸血で{value} HPを回復した"
-  ,"companion-attack-hit": "{companion}は{enemy}に{value}{type}を与えた。"
-  ,"enemy-attack-hit": "{enemy}は{player}に{value}{type}を与え{lifesteal}。"
-  ,"enemy-vamp-heal": "、吸血で{value} HPを回復した"
-  ,"special-ability-attack-hit": "{player}は必殺技で{value}{type}を与え{lifesteal}！"
-  ,"special-ability-heal": "{player}は必殺技を使い{hp} HP回復した！"
-  ,"special-ability-companion-boost": "{player}は{companion}を強化！ATK/APSを5秒間50%アップ。"
-  ,"special-ability-no-companion": "このスキルを使うにはコンパニオンが必要です。"
-  ,"claim": "獲得"
-  ,"start-new-run": "新しいランを開始"
-  ,"attack": "攻撃"
-  ,"special-ability": "必殺技"
-  ,"cooling": "冷却中..."
-  ,"you-leveled-up": "レベルアップ！ (Lv.{previousLvl} > Lv.{newLvl})"
-  ,"level-up": "レベルアップ!"
-  ,"remaining": "残り: {count}"
-  ,"reroll-button": "リロール {remaining}/{total}"
-
-  ,"equipment-names": {
+  "resting-bonus-serenity": "<span style='color: #2196F3;'>🛡️ 心が安らいだ！ (次の階までDEF+12%)</span>",
+  "pray": "祈る",
+  "guardian-blocking-way": "階のガーディアン{enemy}が行く手を阻んでいる。",
+  "you-died-hardcore": "あなたは死んだ！ <span class='Heirloom'>ハードコアモード:</span> すべての<b>インベントリ</b>と<b>ゴールド</b>を失う。",
+  "you-died-softcore": "あなたは死んだ！ <b>インベントリ</b>と<b>ゴールド</b>は保持される。",
+  "enemy-defeated-reward": "{enemy}を倒した: +{exp} exp, <i class='fas fa-coins' style='color: #FFD700;'></i>{gold} ゴールド ({time})",
+  "crit-damage": "クリティカルダメージ",
+  "damage": "ダメージ",
+  "dodged-attack-enemy": "{enemy}は攻撃を回避した！",
+  "dodged-attack-companion": "{enemy}は{companion}の攻撃を回避した！",
+  "dodged-attack-player": "{player}は攻撃を回避した！",
+  "scout-dodged-attack": "{player}は身を翻して攻撃をかわした！",
+  "special-ability-scout-dodge": "{player}は次の攻撃を避ける準備をしている！",
+  "player-attack-hit": "{player}は{enemy}に{value}{type}を与え{lifesteal}。",
+  "player-vamp-heal": "、吸血で{value} HPを回復した",
+  "companion-attack-hit": "{companion}は{enemy}に{value}{type}を与えた。",
+  "enemy-attack-hit": "{enemy}は{player}に{value}{type}を与え{lifesteal}。",
+  "enemy-vamp-heal": "、吸血で{value} HPを回復した",
+  "special-ability-attack-hit": "{player}は必殺技で{value}{type}を与え{lifesteal}！",
+  "special-ability-heal": "{player}は必殺技を使い{hp} HP回復した！",
+  "special-ability-companion-boost": "{player}は{companion}を強化！ATK/APSを5秒間50%アップ。",
+  "special-ability-no-companion": "このスキルを使うにはコンパニオンが必要です。",
+  "claim": "獲得",
+  "start-new-run": "新しいランを開始",
+  "attack": "攻撃",
+  "special-ability": "必殺技",
+  "cooling": "冷却中...",
+  "you-leveled-up": "レベルアップ！ (Lv.{previousLvl} > Lv.{newLvl})",
+  "level-up": "レベルアップ!",
+  "remaining": "残り: {count}",
+  "reroll-button": "リロール {remaining}/{total}",
+  "equipment-names": {
     "sword": "剣",
     "axe": "斧",
     "hammer": "ハンマー",
@@ -378,9 +377,8 @@
     "mask": "マスク",
     "boots": "ブーツ",
     "charm": "チャーム"
-  }
-
-  ,"enemy-names": {
+  },
+  "enemy-names": {
     "goblin": "ゴブリン",
     "goblin-rogue": "ゴブリンローグ",
     "goblin-mage": "ゴブリンメイジ",
@@ -432,22 +430,51 @@
     "thanatos": "タナトス",
     "darkness-angel-reaper": "闇天使リーパー",
     "zalaras-dragon-emperor": "竜皇ザララス"
-  }
-
-  ,"level-up-option": {
-    "hp": { "title": "HP UP", "desc": "ボーナスHPが{value}%増加する。" },
-    "atk": { "title": "ATK UP", "desc": "ボーナスATKが{value}%増加する。" },
-    "def": { "title": "DEF UP", "desc": "ボーナスDEFが{value}%増加する。" },
-    "atkSpd": { "title": "ATK.SPD UP", "desc": "ボーナスATK.SPDが{value}%増加する。" },
-    "vamp": { "title": "VAMP UP", "desc": "ボーナスVAMPが{value}%増加する。" },
-    "critRate": { "title": "C.RATE UP", "desc": "ボーナスC.RATEが{value}%増加する。" },
-    "critDmg": { "title": "C.DMG UP", "desc": "ボーナスC.DMGが{value}%増加する。" },
-    "dodge": { "title": "DODGE UP", "desc": "ボーナスDODGEが{value}%増加する。" },
-    "luck": { "title": "LUCK UP", "desc": "ボーナスLUCKが{value}%増加する。" }
-  }
-
-  ,"descend": "降りる"
-  ,"descended-to-floor": "{floor}階へ降りた。"
-  ,"found-stairs": "ダンジョンの奥へ続く階段を見つけた。"
-
+  },
+  "level-up-option": {
+    "hp": {
+      "title": "HP UP",
+      "desc": "ボーナスHPが{value}%増加する。"
+    },
+    "atk": {
+      "title": "ATK UP",
+      "desc": "ボーナスATKが{value}%増加する。"
+    },
+    "def": {
+      "title": "DEF UP",
+      "desc": "ボーナスDEFが{value}%増加する。"
+    },
+    "atkSpd": {
+      "title": "ATK.SPD UP",
+      "desc": "ボーナスATK.SPDが{value}%増加する。"
+    },
+    "vamp": {
+      "title": "VAMP UP",
+      "desc": "ボーナスVAMPが{value}%増加する。"
+    },
+    "critRate": {
+      "title": "C.RATE UP",
+      "desc": "ボーナスC.RATEが{value}%増加する。"
+    },
+    "critDmg": {
+      "title": "C.DMG UP",
+      "desc": "ボーナスC.DMGが{value}%増加する。"
+    },
+    "dodge": {
+      "title": "DODGE UP",
+      "desc": "ボーナスDODGEが{value}%増加する。"
+    },
+    "luck": {
+      "title": "LUCK UP",
+      "desc": "ボーナスLUCKが{value}%増加する。"
+    }
+  },
+  "descend": "降りる",
+  "descended-to-floor": "{floor}階へ降りた。",
+  "found-stairs": "ダンジョンの奥へ続く階段を見つけた。",
+  "enemy-type-offensive": "攻撃型",
+  "enemy-type-defensive": "防御型",
+  "enemy-type-balanced": "バランス型",
+  "enemy-type-quick": "速度型",
+  "enemy-type-lethal": "致命型"
 }

--- a/assets/locales/ko.json
+++ b/assets/locales/ko.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "공격형",
+  "enemy-type-defensive": "방어형",
+  "enemy-type-balanced": "균형형",
+  "enemy-type-quick": "속도형",
+  "enemy-type-lethal": "치명형"
 }

--- a/assets/locales/pl.json
+++ b/assets/locales/pl.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "Ofensywny",
+  "enemy-type-defensive": "Defensywny",
+  "enemy-type-balanced": "Zrównoważony",
+  "enemy-type-quick": "Szybki",
+  "enemy-type-lethal": "Śmiertelny"
 }

--- a/assets/locales/pt.json
+++ b/assets/locales/pt.json
@@ -450,18 +450,49 @@
     "zalaras-dragon-emperor": "Zalaras, o Imperador Dragão"
   },
   "level-up-option": {
-    "hp": { "title": "HP +", "desc": "Aumenta o HP bônus em {value}%." },
-    "atk": { "title": "ATQ +", "desc": "Aumenta o ATQ bônus em {value}%." },
-    "def": { "title": "DEF +", "desc": "Aumenta a DEF bônus em {value}%." },
-    "atkSpd": { "title": "VEL.ATQ +", "desc": "Aumenta a VEL.ATQ bônus em {value}%." },
-    "vamp": { "title": "VAMP +", "desc": "Aumenta o VAMP bônus em {value}%." },
-    "critRate": { "title": "T.CRÍT +", "desc": "Aumenta a taxa crítica bônus em {value}%." },
-    "critDmg": { "title": "D.CRÍT +", "desc": "Aumenta o dano crítico bônus em {value}%." },
-    "dodge": { "title": "ESQUIVA +", "desc": "Aumenta a esquiva bônus em {value}%." },
-    "luck": { "title": "SORTE +", "desc": "Aumenta a sorte bônus em {value}%." }
+    "hp": {
+      "title": "HP +",
+      "desc": "Aumenta o HP bônus em {value}%."
+    },
+    "atk": {
+      "title": "ATQ +",
+      "desc": "Aumenta o ATQ bônus em {value}%."
+    },
+    "def": {
+      "title": "DEF +",
+      "desc": "Aumenta a DEF bônus em {value}%."
+    },
+    "atkSpd": {
+      "title": "VEL.ATQ +",
+      "desc": "Aumenta a VEL.ATQ bônus em {value}%."
+    },
+    "vamp": {
+      "title": "VAMP +",
+      "desc": "Aumenta o VAMP bônus em {value}%."
+    },
+    "critRate": {
+      "title": "T.CRÍT +",
+      "desc": "Aumenta a taxa crítica bônus em {value}%."
+    },
+    "critDmg": {
+      "title": "D.CRÍT +",
+      "desc": "Aumenta o dano crítico bônus em {value}%."
+    },
+    "dodge": {
+      "title": "ESQUIVA +",
+      "desc": "Aumenta a esquiva bônus em {value}%."
+    },
+    "luck": {
+      "title": "SORTE +",
+      "desc": "Aumenta a sorte bônus em {value}%."
+    }
   },
-
   "descend": "Descer",
   "descended-to-floor": "Você desceu para o andar {floor}.",
-  "found-stairs": "Você encontrou escadas que levam mais fundo na masmorra."
+  "found-stairs": "Você encontrou escadas que levam mais fundo na masmorra.",
+  "enemy-type-offensive": "Ofensivo",
+  "enemy-type-defensive": "Defensivo",
+  "enemy-type-balanced": "Equilibrado",
+  "enemy-type-quick": "Rápido",
+  "enemy-type-lethal": "Letal"
 }

--- a/assets/locales/ro.json
+++ b/assets/locales/ro.json
@@ -469,8 +469,12 @@
       "desc": "Mărește bonusul de LUCK cu {value}%."
     }
   },
-
   "descend": "Coboară",
   "descended-to-floor": "Ai coborât la etajul {floor}.",
-  "found-stairs": "Ai găsit niște scări care duc mai adânc în temniță."
+  "found-stairs": "Ai găsit niște scări care duc mai adânc în temniță.",
+  "enemy-type-offensive": "Ofensiv",
+  "enemy-type-defensive": "Defensiv",
+  "enemy-type-balanced": "Echilibrat",
+  "enemy-type-quick": "Rapid",
+  "enemy-type-lethal": "Letal"
 }

--- a/assets/locales/ru.json
+++ b/assets/locales/ru.json
@@ -432,18 +432,49 @@
     "zalaras-dragon-emperor": "Заларас, император драконов"
   },
   "level-up-option": {
-    "hp": { "title": "HP UP", "desc": "Увеличьте бонусное HP на {value}%." },
-    "atk": { "title": "ATK UP", "desc": "Увеличьте бонусный ATK на {value}%." },
-    "def": { "title": "DEF UP", "desc": "Увеличьте бонусный DEF на {value}%." },
-    "atkSpd": { "title": "ATK.SPD UP", "desc": "Увеличьте бонусный ATK.SPD на {value}%." },
-    "vamp": { "title": "VAMP UP", "desc": "Увеличьте бонусный VAMP на {value}%." },
-    "critRate": { "title": "C.RATE UP", "desc": "Увеличьте бонусный C.RATE на {value}%." },
-    "critDmg": { "title": "C.DMG UP", "desc": "Увеличьте бонусный C.DMG на {value}%." },
-    "dodge": { "title": "DODGE UP", "desc": "Увеличьте бонусный DODGE на {value}%." },
-    "luck": { "title": "LUCK UP", "desc": "Увеличьте бонусный LUCK на {value}%." }
+    "hp": {
+      "title": "HP UP",
+      "desc": "Увеличьте бонусное HP на {value}%."
+    },
+    "atk": {
+      "title": "ATK UP",
+      "desc": "Увеличьте бонусный ATK на {value}%."
+    },
+    "def": {
+      "title": "DEF UP",
+      "desc": "Увеличьте бонусный DEF на {value}%."
+    },
+    "atkSpd": {
+      "title": "ATK.SPD UP",
+      "desc": "Увеличьте бонусный ATK.SPD на {value}%."
+    },
+    "vamp": {
+      "title": "VAMP UP",
+      "desc": "Увеличьте бонусный VAMP на {value}%."
+    },
+    "critRate": {
+      "title": "C.RATE UP",
+      "desc": "Увеличьте бонусный C.RATE на {value}%."
+    },
+    "critDmg": {
+      "title": "C.DMG UP",
+      "desc": "Увеличьте бонусный C.DMG на {value}%."
+    },
+    "dodge": {
+      "title": "DODGE UP",
+      "desc": "Увеличьте бонусный DODGE на {value}%."
+    },
+    "luck": {
+      "title": "LUCK UP",
+      "desc": "Увеличьте бонусный LUCK на {value}%."
+    }
   },
   "descend": "Спуститься",
   "descended-to-floor": "Вы спустились на этаж {floor}.",
-  "found-stairs": "Вы нашли лестницу, ведущую глубже в подземелье."
-
+  "found-stairs": "Вы нашли лестницу, ведущую глубже в подземелье.",
+  "enemy-type-offensive": "Атакующий",
+  "enemy-type-defensive": "Защитный",
+  "enemy-type-balanced": "Сбалансированный",
+  "enemy-type-quick": "Быстрый",
+  "enemy-type-lethal": "Смертоносный"
 }

--- a/assets/locales/tr.json
+++ b/assets/locales/tr.json
@@ -471,5 +471,10 @@
   },
   "descend": "Descend",
   "descended-to-floor": "You descended to floor {floor}.",
-  "found-stairs": "You found stairs leading deeper into the dungeon."
+  "found-stairs": "You found stairs leading deeper into the dungeon.",
+  "enemy-type-offensive": "Saldırgan",
+  "enemy-type-defensive": "Defansif",
+  "enemy-type-balanced": "Dengeli",
+  "enemy-type-quick": "Hızlı",
+  "enemy-type-lethal": "Öldürücü"
 }

--- a/assets/locales/uk.json
+++ b/assets/locales/uk.json
@@ -359,7 +359,6 @@
   "level-up": "Рівень підвищено!",
   "remaining": "Залишилось: {count}",
   "reroll-button": "Перекинути {remaining}/{total}",
-
   "equipment-names": {
     "sword": "Меч",
     "axe": "Сокира",
@@ -379,7 +378,6 @@
     "boots": "Чоботи",
     "charm": "Амулет"
   },
-
   "enemy-names": {
     "goblin": "Гоблін",
     "goblin-rogue": "Гоблін-розбійник",
@@ -433,21 +431,50 @@
     "darkness-angel-reaper": "Темний янгол-жнець",
     "zalaras-dragon-emperor": "Заларас, імператор драконів"
   },
-
   "level-up-option": {
-    "hp": { "title": "HP UP", "desc": "Збільшує бонусне HP на {value}%." },
-    "atk": { "title": "ATK UP", "desc": "Збільшує бонусний ATK на {value}%." },
-    "def": { "title": "DEF UP", "desc": "Збільшує бонусний DEF на {value}%." },
-    "atkSpd": { "title": "ATK.SPD UP", "desc": "Збільшує бонусний ATK.SPD на {value}%." },
-    "vamp": { "title": "VAMP UP", "desc": "Збільшує бонусний VAMP на {value}%." },
-    "critRate": { "title": "C.RATE UP", "desc": "Збільшує бонусний C.RATE на {value}%." },
-    "critDmg": { "title": "C.DMG UP", "desc": "Збільшує бонусний C.DMG на {value}%." },
-    "dodge": { "title": "DODGE UP", "desc": "Збільшує бонусний DODGE на {value}%." },
-    "luck": { "title": "LUCK UP", "desc": "Збільшує бонусний LUCK на {value}%." }
+    "hp": {
+      "title": "HP UP",
+      "desc": "Збільшує бонусне HP на {value}%."
+    },
+    "atk": {
+      "title": "ATK UP",
+      "desc": "Збільшує бонусний ATK на {value}%."
+    },
+    "def": {
+      "title": "DEF UP",
+      "desc": "Збільшує бонусний DEF на {value}%."
+    },
+    "atkSpd": {
+      "title": "ATK.SPD UP",
+      "desc": "Збільшує бонусний ATK.SPD на {value}%."
+    },
+    "vamp": {
+      "title": "VAMP UP",
+      "desc": "Збільшує бонусний VAMP на {value}%."
+    },
+    "critRate": {
+      "title": "C.RATE UP",
+      "desc": "Збільшує бонусний C.RATE на {value}%."
+    },
+    "critDmg": {
+      "title": "C.DMG UP",
+      "desc": "Збільшує бонусний C.DMG на {value}%."
+    },
+    "dodge": {
+      "title": "DODGE UP",
+      "desc": "Збільшує бонусний DODGE на {value}%."
+    },
+    "luck": {
+      "title": "LUCK UP",
+      "desc": "Збільшує бонусний LUCK на {value}%."
+    }
   },
-
   "descend": "Спуститися",
   "descended-to-floor": "Ви спустилися на поверх {floor}.",
-  "found-stairs": "Ви знайшли сходи, що ведуть глибше в підземелля."
-
+  "found-stairs": "Ви знайшли сходи, що ведуть глибше в підземелля.",
+  "enemy-type-offensive": "Атакуючий",
+  "enemy-type-defensive": "Захисний",
+  "enemy-type-balanced": "Збалансований",
+  "enemy-type-quick": "Швидкий",
+  "enemy-type-lethal": "Смертельний"
 }

--- a/assets/locales/zh.json
+++ b/assets/locales/zh.json
@@ -471,5 +471,10 @@
       "title": "幸运提升",
       "desc": "额外幸运加成提高 {value}%。"
     }
-  }
+  },
+  "enemy-type-offensive": "攻击型",
+  "enemy-type-defensive": "防御型",
+  "enemy-type-balanced": "均衡型",
+  "enemy-type-quick": "速度型",
+  "enemy-type-lethal": "致命型"
 }


### PR DESCRIPTION
Translates the enemy type badge (Offensive, Defensive, Balanced, Quick, Lethal) into all 17 supported languages using i18n keys.