### PR TITLE
fix: show Aegis Thorns reflected damage in combat log

### DIFF
--- a/assets/js/combat.js
+++ b/assets/js/combat.js
@@ -962,6 +962,10 @@ const enemyAttack = () => {
         if (typeof recordRunDamageDealt === 'function') {
             recordRunDamageDealt(reflectedDamage);
         }
+        addCombatLog(t('aegis-thorns-reflect', {
+            enemy: getDisplayEnemyName(enemy.id, enemy.name),
+            value: nFormatter(reflectedDamage)
+        }));
     }
     enemy.stats.hp += lifesteal;
     if (!dodged) {

--- a/assets/locales/ar.json
+++ b/assets/locales/ar.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "دفاعي",
   "enemy-type-balanced": "متوازن",
   "enemy-type-quick": "سريع",
-  "enemy-type-lethal": "فتاك"
+  "enemy-type-lethal": "فتاك,",
+  "aegis-thorns-reflect": "يتلقى {enemy} {value} من الضرر المنعكس!"
 }

--- a/assets/locales/de.json
+++ b/assets/locales/de.json
@@ -494,5 +494,6 @@
   "enemy-type-defensive": "Defensiv",
   "enemy-type-balanced": "Ausgewogen",
   "enemy-type-quick": "Schnell",
-  "enemy-type-lethal": "Tödlich"
+  "enemy-type-lethal": "Tödlich,",
+  "aegis-thorns-reflect": "{enemy} erhält {value} reflektierten Schaden!"
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensive",
   "enemy-type-balanced": "Balanced",
   "enemy-type-quick": "Quick",
-  "enemy-type-lethal": "Lethal"
+  "enemy-type-lethal": "Lethal",
+  "aegis-thorns-reflect": "{enemy} takes {value} reflected damage!"
 }

--- a/assets/locales/es.json
+++ b/assets/locales/es.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensivo",
   "enemy-type-balanced": "Equilibrado",
   "enemy-type-quick": "Rápido",
-  "enemy-type-lethal": "Letal"
+  "enemy-type-lethal": "Letal,",
+  "aegis-thorns-reflect": "{enemy} recibe {value} de daño reflejado!"
 }

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Défensif",
   "enemy-type-balanced": "Équilibré",
   "enemy-type-quick": "Rapide",
-  "enemy-type-lethal": "Létal"
+  "enemy-type-lethal": "Létal,",
+  "aegis-thorns-reflect": "{enemy} subit {value} de dégâts réfléchis !"
 }

--- a/assets/locales/hi.json
+++ b/assets/locales/hi.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "रक्षात्मक",
   "enemy-type-balanced": "संतुलित",
   "enemy-type-quick": "तेज़",
-  "enemy-type-lethal": "घातक"
+  "enemy-type-lethal": "घातक,",
+  "aegis-thorns-reflect": "{enemy} को {value} प्रतिबिंबित नुकसान होता है!"
 }

--- a/assets/locales/id.json
+++ b/assets/locales/id.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensif",
   "enemy-type-balanced": "Seimbang",
   "enemy-type-quick": "Cepat",
-  "enemy-type-lethal": "Mematikan"
+  "enemy-type-lethal": "Mematikan,",
+  "aegis-thorns-reflect": "{enemy} menerima {value} kerusakan terpantul!"
 }

--- a/assets/locales/it.json
+++ b/assets/locales/it.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Difensivo",
   "enemy-type-balanced": "Bilanciato",
   "enemy-type-quick": "Veloce",
-  "enemy-type-lethal": "Letale"
+  "enemy-type-lethal": "Letale,",
+  "aegis-thorns-reflect": "{enemy} subisce {value} danni riflessi!"
 }

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "防御型",
   "enemy-type-balanced": "バランス型",
   "enemy-type-quick": "速度型",
-  "enemy-type-lethal": "致命型"
+  "enemy-type-lethal": "致命型,",
+  "aegis-thorns-reflect": "{enemy}は{value}の反射ダメージを受けた！"
 }

--- a/assets/locales/ko.json
+++ b/assets/locales/ko.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "방어형",
   "enemy-type-balanced": "균형형",
   "enemy-type-quick": "속도형",
-  "enemy-type-lethal": "치명형"
+  "enemy-type-lethal": "치명형,",
+  "aegis-thorns-reflect": "{enemy}이(가) {value}의 반사 대미지를 받습니다!"
 }

--- a/assets/locales/pl.json
+++ b/assets/locales/pl.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensywny",
   "enemy-type-balanced": "Zrównoważony",
   "enemy-type-quick": "Szybki",
-  "enemy-type-lethal": "Śmiertelny"
+  "enemy-type-lethal": "Śmiertelny,",
+  "aegis-thorns-reflect": "{enemy} otrzymuje {value} odbitego obrażenia!"
 }

--- a/assets/locales/pt.json
+++ b/assets/locales/pt.json
@@ -494,5 +494,6 @@
   "enemy-type-defensive": "Defensivo",
   "enemy-type-balanced": "Equilibrado",
   "enemy-type-quick": "Rápido",
-  "enemy-type-lethal": "Letal"
+  "enemy-type-lethal": "Letal,",
+  "aegis-thorns-reflect": "{enemy} recebe {value} de dano refletido!"
 }

--- a/assets/locales/ro.json
+++ b/assets/locales/ro.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensiv",
   "enemy-type-balanced": "Echilibrat",
   "enemy-type-quick": "Rapid",
-  "enemy-type-lethal": "Letal"
+  "enemy-type-lethal": "Letal,",
+  "aegis-thorns-reflect": "{enemy} primește {value} daună reflectată!"
 }

--- a/assets/locales/ru.json
+++ b/assets/locales/ru.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Защитный",
   "enemy-type-balanced": "Сбалансированный",
   "enemy-type-quick": "Быстрый",
-  "enemy-type-lethal": "Смертоносный"
+  "enemy-type-lethal": "Смертоносный,",
+  "aegis-thorns-reflect": "{enemy} получает {value} отражённого урона!"
 }

--- a/assets/locales/tr.json
+++ b/assets/locales/tr.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Savunmacı",
   "enemy-type-balanced": "Dengeli",
   "enemy-type-quick": "Hızlı",
-  "enemy-type-lethal": "Öldürücü"
+  "enemy-type-lethal": "Öldürücü,",
+  "aegis-thorns-reflect": "{enemy} {value} yansıyan hasar alıyor!"
 }

--- a/assets/locales/uk.json
+++ b/assets/locales/uk.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Захисний",
   "enemy-type-balanced": "Збалансований",
   "enemy-type-quick": "Швидкий",
-  "enemy-type-lethal": "Смертельний"
+  "enemy-type-lethal": "Смертельний,",
+  "aegis-thorns-reflect": "{enemy} отримує {value} відбитого пошкодження!"
 }

--- a/assets/locales/zh.json
+++ b/assets/locales/zh.json
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "防御型",
   "enemy-type-balanced": "均衡型",
   "enemy-type-quick": "速度型",
-  "enemy-type-lethal": "致命型"
+  "enemy-type-lethal": "致命型,",
+  "aegis-thorns-reflect": "{enemy}受到{value}反射伤害！"
 }


### PR DESCRIPTION
## Fix: Aegis Thorns — Combat Log Feedback

**Problem:** Aegis Thorns (enemies receive 30% of the damage they dealt) was working correctly in the code but **not shown in the combat log** — players had no visual confirmation that the passive was triggering.

**Fix:**
- Added `addCombatLog(t("aegis-thorns-reflect", { enemy, value }))` in `combat.js`
- Translated the new key `aegis-thorns-reflect` across all 17 locales

**Triggered by:** Reddit user HiimDang reporting the passive "not working as expected" — it was working, just invisible.

---
*Dev note: The passive was confirmed working by logTom. This only adds the missing visual feedback.*