### PR TITLE
fix: integrate Aegis Thorns into enemy-attack-hit log message

### DIFF
--- a/assets/js/combat.js
+++ b/assets/js/combat.js
@@ -953,8 +953,8 @@ const enemyAttack = () => {
     if (typeof recordRunDamageTaken === 'function') {
         recordRunDamageTaken(damage);
     }
-    // Aegis Thorns skill
-    objectValidation();
+    enemy.stats.hp += lifesteal;
+    let thornsText = '';
     if (player.skills.includes("Aegis Thorns")) {
         // Enemies receive 30% of the damage they dealt
         const reflectedDamage = Math.round((30 * damage) / 100);
@@ -962,8 +962,8 @@ const enemyAttack = () => {
         if (typeof recordRunDamageDealt === 'function') {
             recordRunDamageDealt(reflectedDamage);
         }
+        thornsText = t('thorns-reflect', { value: nFormatter(reflectedDamage) });
     }
-    enemy.stats.hp += lifesteal;
     if (!dodged) {
         const lifestealText = lifesteal > 0 ? t('enemy-vamp-heal', { value: nFormatter(lifesteal) }) : '';
         addCombatLog(t('enemy-attack-hit', {
@@ -971,7 +971,8 @@ const enemyAttack = () => {
             player: player.name,
             value: nFormatter(damage),
             type: dmgtype,
-            lifesteal: lifestealText
+            lifesteal: lifestealText,
+            thorns: thornsText
         }));
     }
     hpValidation();

--- a/assets/locales/ar.json
+++ b/assets/locales/ar.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "سبب {player} مقدار {value} {type} إلى {enemy}{lifesteal}.",
   "player-vamp-heal": "، وشفى {value} HP من مص الحياة",
   "companion-attack-hit": "سبب {companion} مقدار {value} {type} إلى {enemy}.",
-  "enemy-attack-hit": "سبب {enemy} مقدار {value} {type} إلى {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} سبب {value} {type} إلى {player}{lifesteal}، وتلقى {thorns} من الضرر المنعكس!",
   "enemy-vamp-heal": "، وشفى {value} HP من مص الحياة",
   "special-ability-attack-hit": "أطلق {player} قدرة خاصة بمقدار {value} {type}{lifesteal}!",
   "special-ability-heal": "استخدم {player} قدرة خاصة وشفى {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "دفاعي",
   "enemy-type-balanced": "متوازن",
   "enemy-type-quick": "سريع",
-  "enemy-type-lethal": "فتاك"
+  "enemy-type-lethal": "فتاك",
+  "thorns-reflect": "وتلقى {value} من الضرر المنعكس"
 }

--- a/assets/locales/de.json
+++ b/assets/locales/de.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} verursacht {value} {type} an {enemy}{lifesteal}.",
   "player-vamp-heal": ", und heilte {value} HP durch Vampirismus",
   "companion-attack-hit": "{companion} verursacht {value} {type} an {enemy}.",
-  "enemy-attack-hit": "{enemy} verursacht {value} {type} an {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} verursacht {value} {type} an {player}{lifesteal} und erhielt {thorns} reflektierten Schaden!",
   "enemy-vamp-heal": ", und heilte {value} HP durch Vampirismus",
   "special-ability-attack-hit": "{player} entfesselt eine Spezialfähigkeit für {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} nutzt eine Spezialfähigkeit und heilt {hp} HP!",
@@ -494,5 +494,6 @@
   "enemy-type-defensive": "Defensiv",
   "enemy-type-balanced": "Ausgewogen",
   "enemy-type-quick": "Schnell",
-  "enemy-type-lethal": "Tödlich"
+  "enemy-type-lethal": "Tödlich",
+  "thorns-reflect": "und erhielt {value} reflektierten Schaden"
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} dealt {value} {type} to {enemy}{lifesteal}.",
   "player-vamp-heal": ", and healed {value} HP from vampirism",
   "companion-attack-hit": "{companion} dealt {value} {type} to {enemy}.",
-  "enemy-attack-hit": "{enemy} dealt {value} {type} to {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} dealt {value} {type} to {player}{lifesteal}, and took {thorns} reflected damage!",
   "enemy-vamp-heal": ", and healed {value} HP from vampirism",
   "special-ability-attack-hit": "{player} unleashed a special ability for {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} used a special ability and healed {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensive",
   "enemy-type-balanced": "Balanced",
   "enemy-type-quick": "Quick",
-  "enemy-type-lethal": "Lethal"
+  "enemy-type-lethal": "Lethal",
+  "thorns-reflect": "and took {value} reflected damage"
 }

--- a/assets/locales/es.json
+++ b/assets/locales/es.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} infligió {value} {type} a {enemy}{lifesteal}.",
   "player-vamp-heal": ", y se curó {value} HP por vampirismo",
   "companion-attack-hit": "{companion} infligió {value} {type} a {enemy}.",
-  "enemy-attack-hit": "{enemy} infligió {value} {type} a {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} infligió {value} {type} a {player}{lifesteal}, y recibió {thorns} de daño reflejado!",
   "enemy-vamp-heal": ", y se curó {value} HP por vampirismo",
   "special-ability-attack-hit": "{player} desató una habilidad especial por {value} de {type}{lifesteal}!",
   "special-ability-heal": "{player} usó una habilidad especial y curó {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensivo",
   "enemy-type-balanced": "Equilibrado",
   "enemy-type-quick": "Rápido",
-  "enemy-type-lethal": "Letal"
+  "enemy-type-lethal": "Letal",
+  "thorns-reflect": "y recibió {value} de daño reflejado"
 }

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} a infligé {value} {type} à {enemy}{lifesteal}.",
   "player-vamp-heal": " et a récupéré {value} PV grâce au vampirisme",
   "companion-attack-hit": "{companion} a infligé {value} {type} à {enemy}.",
-  "enemy-attack-hit": "{enemy} a infligé {value} {type} à {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} a infligé {value} {type} à {player}{lifesteal}, et subit {thorns} de dégâts réfléchis!",
   "enemy-vamp-heal": " et a récupéré {value} PV grâce au vampirisme",
   "special-ability-attack-hit": "{player} a déchaîné une capacité spéciale pour {value} {type}{lifesteal} !",
   "special-ability-heal": "{player} a utilisé une capacité spéciale et récupéré {hp} PV !",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Défensif",
   "enemy-type-balanced": "Équilibré",
   "enemy-type-quick": "Rapide",
-  "enemy-type-lethal": "Létal"
+  "enemy-type-lethal": "Létal",
+  "thorns-reflect": "et subit {value} de dégâts réfléchis"
 }

--- a/assets/locales/hi.json
+++ b/assets/locales/hi.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} ने {enemy} को {value} {type} दिया{lifesteal}।",
   "player-vamp-heal": ", और वैम्पिरिज्म से {value} HP ठीक किया",
   "companion-attack-hit": "{companion} ने {enemy} को {value} {type} दिया।",
-  "enemy-attack-hit": "{enemy} ने {player} को {value} {type} दिया{lifesteal}।",
+  "enemy-attack-hit": "{enemy} ने {player} को {value} {type} दिया{lifesteal}।, और {thorns} प्रतिबिंबित नुकसान सहा!",
   "enemy-vamp-heal": ", और वैम्पिरिज्म से {value} HP ठीक किया",
   "special-ability-attack-hit": "{player} ने {value} {type}{lifesteal} के लिए विशेष क्षमता छोड़ी!",
   "special-ability-heal": "{player} ने विशेष क्षमता का उपयोग किया और {hp} HP ठीक किया!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "रक्षात्मक",
   "enemy-type-balanced": "संतुलित",
   "enemy-type-quick": "तेज़",
-  "enemy-type-lethal": "घातक"
+  "enemy-type-lethal": "घातक",
+  "thorns-reflect": "और {value} प्रतिबिंबित नुकसान सहा"
 }

--- a/assets/locales/id.json
+++ b/assets/locales/id.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} memberikan {value} {type} kepada {enemy}{lifesteal}.",
   "player-vamp-heal": ", dan memulihkan {value} HP dari vampirisme",
   "companion-attack-hit": "{companion} memberikan {value} {type} kepada {enemy}.",
-  "enemy-attack-hit": "{enemy} memberikan {value} {type} kepada {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} memberikan {value} {type} kepada {player}{lifesteal}, dan menerima {thorns} kerusakan terpantul!",
   "enemy-vamp-heal": ", dan memulihkan {value} HP dari vampirisme",
   "special-ability-attack-hit": "{player} melepaskan kemampuan khusus untuk {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} menggunakan kemampuan khusus dan memulihkan {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensif",
   "enemy-type-balanced": "Seimbang",
   "enemy-type-quick": "Cepat",
-  "enemy-type-lethal": "Mematikan"
+  "enemy-type-lethal": "Mematikan",
+  "thorns-reflect": "dan menerima {value} kerusakan terpantul"
 }

--- a/assets/locales/it.json
+++ b/assets/locales/it.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} ha inflitto {value} {type} a {enemy}{lifesteal}.",
   "player-vamp-heal": " e ha recuperato {value} PV dal vampirismo",
   "companion-attack-hit": "{companion} ha inflitto {value} {type} a {enemy}.",
-  "enemy-attack-hit": "{enemy} ha inflitto {value} {type} a {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} ha inflitto {value} {type} a {player}{lifesteal}, e subì {thorns} danni riflessi!",
   "enemy-vamp-heal": " e ha recuperato {value} PV dal vampirismo",
   "special-ability-attack-hit": "{player} ha scatenato un'abilità speciale per {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} ha usato un'abilità speciale e ha recuperato {hp} PV!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Difensivo",
   "enemy-type-balanced": "Bilanciato",
   "enemy-type-quick": "Veloce",
-  "enemy-type-lethal": "Letale"
+  "enemy-type-lethal": "Letale",
+  "thorns-reflect": "e subì {value} danni riflessi"
 }

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player}は{enemy}に{value}{type}を与え{lifesteal}。",
   "player-vamp-heal": "、吸血で{value} HPを回復した",
   "companion-attack-hit": "{companion}は{enemy}に{value}{type}を与えた。",
-  "enemy-attack-hit": "{enemy}は{player}に{value}{type}を与え{lifesteal}。",
+  "enemy-attack-hit": "{enemy}は{player}に{value}{type}を与え{lifesteal}、さらに{thorns}の反射ダメージを受けた！",
   "enemy-vamp-heal": "、吸血で{value} HPを回復した",
   "special-ability-attack-hit": "{player}は必殺技で{value}{type}を与え{lifesteal}！",
   "special-ability-heal": "{player}は必殺技を使い{hp} HP回復した！",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "防御型",
   "enemy-type-balanced": "バランス型",
   "enemy-type-quick": "速度型",
-  "enemy-type-lethal": "致命型"
+  "enemy-type-lethal": "致命型",
+  "thorns-reflect": "{value}の反射ダメージを受けた"
 }

--- a/assets/locales/ko.json
+++ b/assets/locales/ko.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player}이(가) {enemy}에게 {value} {type}를 가했습니다{lifesteal}.",
   "player-vamp-heal": ", 흡혈로 {value} HP를 회복했습니다",
   "companion-attack-hit": "{companion}이(가) {enemy}에게 {value} {type}를 가했습니다.",
-  "enemy-attack-hit": "{enemy}이(가) {player}에게 {value} {type}를 가했습니다{lifesteal}.",
+  "enemy-attack-hit": "{enemy}이(가) {player}에게 {value} {type}를 가했습니다{lifesteal}, {thorns}의 반사 대미지를 받았습니다!",
   "enemy-vamp-heal": ", 흡혈로 {value} HP를 회복했습니다",
   "special-ability-attack-hit": "{player}이(가) 특수 능력을 해방해 {value} {type}{lifesteal}를 가했습니다!",
   "special-ability-heal": "{player}이(가) 특수 능력을 사용해 {hp} HP를 회복했습니다!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "방어형",
   "enemy-type-balanced": "균형형",
   "enemy-type-quick": "속도형",
-  "enemy-type-lethal": "치명형"
+  "enemy-type-lethal": "치명형",
+  "thorns-reflect": "{value}의 반사 대미지를 받았습니다"
 }

--- a/assets/locales/pl.json
+++ b/assets/locales/pl.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} zadał {value} {type} przeciwnikowi {enemy}{lifesteal}.",
   "player-vamp-heal": " i odzyskał {value} PW dzięki wampiryzmowi",
   "companion-attack-hit": "{companion} zadał {value} {type} przeciwnikowi {enemy}.",
-  "enemy-attack-hit": "{enemy} zadał {value} {type} graczowi {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} zadał {value} {type} graczowi {player}{lifesteal}, i otrzymał {thorns} odbitego obrażenia!",
   "enemy-vamp-heal": " i odzyskał {value} PW dzięki wampiryzmowi",
   "special-ability-attack-hit": "{player} uwolnił zdolność specjalną za {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} użył zdolności specjalnej i odzyskał {hp} PW!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensywny",
   "enemy-type-balanced": "Zrównoważony",
   "enemy-type-quick": "Szybki",
-  "enemy-type-lethal": "Śmiertelny"
+  "enemy-type-lethal": "Śmiertelny",
+  "thorns-reflect": "i otrzymał {value} odbitego obrażenia"
 }

--- a/assets/locales/pt.json
+++ b/assets/locales/pt.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} causou {value} {type} em {enemy}{lifesteal}.",
   "player-vamp-heal": ", e curou {value} HP com vampirismo",
   "companion-attack-hit": "{companion} causou {value} {type} em {enemy}.",
-  "enemy-attack-hit": "{enemy} causou {value} {type} em {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} causou {value} {type} em {player}{lifesteal}, e recebeu {thorns} de dano refletido!",
   "enemy-vamp-heal": ", e curou {value} HP com vampirismo",
   "special-ability-attack-hit": "{player} liberou uma habilidade especial e causou {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} usou uma habilidade especial e curou {hp} HP!",
@@ -494,5 +494,6 @@
   "enemy-type-defensive": "Defensivo",
   "enemy-type-balanced": "Equilibrado",
   "enemy-type-quick": "Rápido",
-  "enemy-type-lethal": "Letal"
+  "enemy-type-lethal": "Letal",
+  "thorns-reflect": "e recebeu {value} de dano refletido"
 }

--- a/assets/locales/ro.json
+++ b/assets/locales/ro.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} a provocat {value} {type} lui {enemy}{lifesteal}.",
   "player-vamp-heal": ", și a vindecat {value} HP prin vampirism",
   "companion-attack-hit": "{companion} a provocat {value} {type} lui {enemy}.",
-  "enemy-attack-hit": "{enemy} a provocat {value} {type} lui {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} a provocat {value} {type} lui {player}{lifesteal}, și a primit {thorns} daună reflectată!",
   "enemy-vamp-heal": ", și a vindecat {value} HP prin vampirism",
   "special-ability-attack-hit": "{player} a dezlănțuit o abilitate specială pentru {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} a folosit o abilitate specială și a vindecat {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Defensiv",
   "enemy-type-balanced": "Echilibrat",
   "enemy-type-quick": "Rapid",
-  "enemy-type-lethal": "Letal"
+  "enemy-type-lethal": "Letal",
+  "thorns-reflect": "și a primit {value} daună reflectată"
 }

--- a/assets/locales/ru.json
+++ b/assets/locales/ru.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} нанёс {value} {type} по {enemy}{lifesteal}.",
   "player-vamp-heal": ", и исцелился на {value} HP от вампиризма",
   "companion-attack-hit": "{companion} нанёс {value} {type} по {enemy}.",
-  "enemy-attack-hit": "{enemy} нанёс {value} {type} по {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} нанёс {value} {type} по {player}{lifesteal}, и получил {thorns} отражённого урона!",
   "enemy-vamp-heal": ", и исцелился на {value} HP от вампиризма",
   "special-ability-attack-hit": "{player} применил особую способность на {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} использовал особую способность и исцелился на {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Защитный",
   "enemy-type-balanced": "Сбалансированный",
   "enemy-type-quick": "Быстрый",
-  "enemy-type-lethal": "Смертоносный"
+  "enemy-type-lethal": "Смертоносный",
+  "thorns-reflect": "и получил {value} отражённого урона"
 }

--- a/assets/locales/tr.json
+++ b/assets/locales/tr.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player}, {enemy} hedefine {value} {type} verdi{lifesteal}.",
   "player-vamp-heal": " ve vampirlikten {value} HP iyileşti",
   "companion-attack-hit": "{companion}, {enemy} hedefine {value} {type} verdi.",
-  "enemy-attack-hit": "{enemy}, {player} hedefine {value} {type} verdi{lifesteal}.",
+  "enemy-attack-hit": "{enemy}, {player} hedefine {value} {type} verdi{lifesteal}, {thorns} yansıyan hasar aldı!",
   "enemy-vamp-heal": " ve vampirlikten {value} HP iyileşti",
   "special-ability-attack-hit": "{player}, {value} {type}{lifesteal} için özel yetenek kullandı!",
   "special-ability-heal": "{player} özel yetenek kullandı ve {hp} HP iyileşti!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Savunmacı",
   "enemy-type-balanced": "Dengeli",
   "enemy-type-quick": "Hızlı",
-  "enemy-type-lethal": "Öldürücü"
+  "enemy-type-lethal": "Öldürücü",
+  "thorns-reflect": "{value} yansıyan hasar aldı"
 }

--- a/assets/locales/uk.json
+++ b/assets/locales/uk.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} завдав {value} {type} {enemy}{lifesteal}.",
   "player-vamp-heal": ", і відновив {value} HP з вампіризму",
   "companion-attack-hit": "{companion} завдав {value} {type} {enemy}.",
-  "enemy-attack-hit": "{enemy} завдав {value} {type} {player}{lifesteal}.",
+  "enemy-attack-hit": "{enemy} завдав {value} {type} {player}{lifesteal}, і отримав {thorns} відбитого пошкодження!",
   "enemy-vamp-heal": ", і відновив {value} HP з вампіризму",
   "special-ability-attack-hit": "{player} застосував особливу здібність на {value} {type}{lifesteal}!",
   "special-ability-heal": "{player} використав особливу здібність і зцілив {hp} HP!",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "Захисний",
   "enemy-type-balanced": "Збалансований",
   "enemy-type-quick": "Швидкий",
-  "enemy-type-lethal": "Смертельний"
+  "enemy-type-lethal": "Смертельний",
+  "thorns-reflect": "і отримав {value} відбитого пошкодження"
 }

--- a/assets/locales/zh.json
+++ b/assets/locales/zh.json
@@ -344,7 +344,7 @@
   "player-attack-hit": "{player} 对 {enemy} 造成了 {value} 点{type}{lifesteal}。",
   "player-vamp-heal": "，并通过吸血恢复了 {value} 点生命",
   "companion-attack-hit": "{companion} 对 {enemy} 造成了 {value} 点{type}。",
-  "enemy-attack-hit": "{enemy} 对 {player} 造成了 {value} 点{type}{lifesteal}。",
+  "enemy-attack-hit": "{enemy} 对 {player} 造成了 {value} 点{type}{lifesteal}，受到{thorns}反射伤害！",
   "enemy-vamp-heal": "，并通过吸血恢复了 {value} 点生命",
   "special-ability-attack-hit": "{player} 释放了特殊技能，造成 {value} 点{type}{lifesteal}！",
   "special-ability-heal": "{player} 使用特殊技能并恢复了 {hp} 点生命！",
@@ -476,5 +476,6 @@
   "enemy-type-defensive": "防御型",
   "enemy-type-balanced": "均衡型",
   "enemy-type-quick": "速度型",
-  "enemy-type-lethal": "致命型"
+  "enemy-type-lethal": "致命型",
+  "thorns-reflect": "受到{value}反射伤害"
 }


### PR DESCRIPTION
## Why

The Aegis Thorns passive was working in the background but had no visual feedback. A separate log entry felt disconnected. Since Vampirism shows its lifesteal as an inline suffix to the attack message, Thorns should work the same way.

Source: Reddit user HiimDang reporting the passive "not working as expected" — it was working, just invisible.

## Changes

- Merged Aegis Thorns reflected damage into the `enemy-attack-hit` message as an inline suffix
- Styled identically to the Vampirism lifesteal suffix: appended after the main damage line
- Added `thorns-reflect` key for the suffix text (17 locales)

## Issue

Passive felt broken because no visual feedback appeared in the combat log.

## Testing

- Equip Aegis Thorns passive, enter combat
- Verify enemy attacks show reflected damage appended inline
- Test with and without Vampirism active (both suffixes should work together)

## Verification

- [ ] Combat log shows reflected damage inline after enemy attack
- [ ] No separate log entry for Thorns
- [ ] All 17 locales display correctly