### PR TITLE
fix: scale stairs minimum level with floor

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -578,7 +578,7 @@ const dungeonEvent = () => {
         if (dungeon.story.monarchUnlocked && !dungeon.story.monarchSeen) {
             eventTypes.push("monarch", "monarch", "monarch");
         }
-        if ( dungeon.progress.floor < 5 && dungeon.progress.room === 1 && player.equipped.length === 6 && player.lvl > 2 && !dungeon.roomEvents.stairsIgnored) {
+        if ( dungeon.progress.floor < 5 && dungeon.progress.room === 1 && player.equipped.length === 6 && player.lvl > 2 && player.lvl > dungeon.progress.floor && !dungeon.roomEvents.stairsIgnored) {
         	eventTypes.push("stairs");
         	eventTypes.push("stairs");
         }


### PR DESCRIPTION
## Summary

- preserve the existing minimum of level 3 for early stairs
- require the player level to be higher than the current floor
- prevent descending from floor 4 to floor 5 before reaching level 5

## Result

| Transition | Minimum level |
| --- | ---: |
| Floor 1 → 2 | 3 |
| Floor 2 → 3 | 3 |
| Floor 3 → 4 | 4 |
| Floor 4 → 5 | 5 |

All existing requirements remain unchanged: room 1, six equipped items, floor below 5, and stairs not previously ignored.

## Verification

- `node --check assets/js/dungeon.js`
- verified the floor/level truth table, including floor 4 at levels 3, 4, and 5
- `git diff --check`