### PR TITLE
refactor: centralize progression limits

### DIFF
--- a/assets/js/companion.js
+++ b/assets/js/companion.js
@@ -565,7 +565,7 @@ function getPermanentCompanionFindCredit() {
         curseLevel = Math.round((Number(dungeon.settings.enemyScaling) - 1) * 10);
     }
 
-    return Math.max(1, Math.min(10, Math.round(curseLevel)));
+    return Math.max(MIN_CURSE_LEVEL, Math.min(MAX_STANDARD_CURSE_LEVEL, Math.round(curseLevel)));
 }
 
 function announcePermanentCompanionUnlock(companionId) {

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -274,7 +274,7 @@ const ensureRunStatisticsShape = () => {
         stats.latestCurseUnlock = null;
     } else {
         const normalized = Math.round(stats.latestCurseUnlock);
-        stats.latestCurseUnlock = Math.min(10, Math.max(1, normalized));
+        stats.latestCurseUnlock = Math.min(MAX_CURSE_LEVEL, Math.max(MIN_CURSE_LEVEL, normalized));
     }
 };
 

--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -204,10 +204,7 @@ const createEquipment = (addToInventory = true, options = {}) => {
     };
     const maxLvl = dungeon.progress.floor * dungeon.settings.enemyLvlGap + (dungeon.settings.enemyBaseLvl - 1);
     const minLvl = maxLvl - (dungeon.settings.enemyLvlGap - 1);
-    equipment.lvl = randomizeNum(minLvl, maxLvl);
-    if (equipment.lvl > 100) {
-        equipment.lvl = 100;
-    }
+    equipment.lvl = clampEquipmentLevel(randomizeNum(minLvl, maxLvl));
     const shouldCreateCompanionCharm = allowCompanionCharm && Math.random() < COMPANION_CHARM_DROP_CHANCE;
     if (shouldCreateCompanionCharm) {
         equipment.attribute = 'Companion';

--- a/assets/js/forge.js
+++ b/assets/js/forge.js
@@ -980,7 +980,7 @@ const calculateForgeResult = () => {
     // Determine possible level range
     const avgLvl = Math.round((item1.lvl + item2.lvl + item3.lvl) / 3);
     const minLvl = Math.max(1, avgLvl - 1);
-    const maxLvl = Math.min(100, avgLvl + 2);
+    const maxLvl = clampEquipmentLevel(avgLvl + 2);
     forgeLevelRange = { min: minLvl, max: maxLvl };
 
     // Calculate result equipment
@@ -1004,7 +1004,7 @@ const createForgedEquipment = (item1, item2, item3) => {
     // Set level roughly around the average of the input items
     const avgLvl = Math.round((item1.lvl + item2.lvl + item3.lvl) / 3);
     const minLvl = Math.max(1, avgLvl - 1);
-    const maxLvl = Math.min(100, avgLvl + 2);
+    const maxLvl = clampEquipmentLevel(avgLvl + 2);
     forgedEquipment.lvl = randomizeNum(minLvl, maxLvl);
 
     // Increase rarity by one step if possible

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1118,21 +1118,6 @@ const saveData = () => {
     }
 }
 
-const clampCurseLevel = (value) => {
-    let level = Number(value);
-    if (!Number.isFinite(level)) {
-        level = 1;
-    }
-    level = Math.round(level);
-    if (level < 1) {
-        level = 1;
-    }
-    if (level > 10) {
-        level = 10;
-    }
-    return level;
-};
-
 const maybeUnlockNextCurseLevel = () => {
     if (!player || !dungeon || !dungeon.progress || !dungeon.settings) {
         return;
@@ -1142,7 +1127,7 @@ const maybeUnlockNextCurseLevel = () => {
     }
     player.maxUnlockedCurseLevel = clampCurseLevel(player.maxUnlockedCurseLevel);
     const maxUnlocked = player.maxUnlockedCurseLevel;
-    if (maxUnlocked >= 10) {
+    if (maxUnlocked >= MAX_CURSE_LEVEL) {
         return;
     }
     const selectedLevel = clampCurseLevel(player.selectedCurseLevel || 1);

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -4,20 +4,6 @@ let luckAsLevelUpOption = localStorage.getItem("luckAsLevelUpOption") === "true"
 
 // Ensure newly added stats exist on old saves
 if (player) {
-    const clampCurseLevel = (value) => {
-        let level = Number(value);
-        if (!Number.isFinite(level)) {
-            level = 1;
-        }
-        level = Math.round(level);
-        if (level < 1) {
-            level = 1;
-        }
-        if (level > 10) {
-            level = 10;
-        }
-        return level;
-    };
     if (typeof player.preferences !== 'object' || player.preferences === null) {
         player.preferences = {};
     }

--- a/assets/js/progression.js
+++ b/assets/js/progression.js
@@ -1,0 +1,22 @@
+const MIN_CURSE_LEVEL = 1;
+const MAX_STANDARD_CURSE_LEVEL = 10;
+const MAX_CURSE_LEVEL = MAX_STANDARD_CURSE_LEVEL;
+const MAX_EQUIPMENT_LEVEL = 100;
+
+const clampCurseLevel = (value) => {
+    let level = Number(value);
+    if (!Number.isFinite(level)) {
+        level = MIN_CURSE_LEVEL;
+    }
+    level = Math.round(level);
+    return Math.min(MAX_CURSE_LEVEL, Math.max(MIN_CURSE_LEVEL, level));
+};
+
+const clampEquipmentLevel = (value) => {
+    let level = Number(value);
+    if (!Number.isFinite(level)) {
+        level = 1;
+    }
+    level = Math.round(level);
+    return Math.min(MAX_EQUIPMENT_LEVEL, Math.max(1, level));
+};

--- a/index.html
+++ b/index.html
@@ -307,6 +307,7 @@
         </div>
     </main>
 	<script src="./assets/js/howler.min.js"></script>
+    <script src="./assets/js/progression.js"></script>
     <script src="./assets/js/utility.js"></script>
     <script src="./assets/js/elements.js"></script>
     <script src="./assets/js/music.js"></script>

--- a/tests/progression-limits.test.js
+++ b/tests/progression-limits.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const progressionSource = fs.readFileSync(path.join(root, 'assets/js/progression.js'), 'utf8');
+
+const evaluateProgression = (expression) => {
+    const context = vm.createContext({});
+    vm.runInContext(progressionSource, context);
+    return vm.runInContext(expression, context);
+};
+
+test('active progression limits preserve the current gameplay caps', () => {
+    const limits = evaluateProgression(`({
+        minCurse: MIN_CURSE_LEVEL,
+        maxStandardCurse: MAX_STANDARD_CURSE_LEVEL,
+        maxCurse: MAX_CURSE_LEVEL,
+        maxEquipment: MAX_EQUIPMENT_LEVEL,
+    })`);
+
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(limits)),
+        { minCurse: 1, maxStandardCurse: 10, maxCurse: 10, maxEquipment: 100 },
+    );
+});
+
+test('curse values from old or malformed saves are normalized as before', () => {
+    const cases = [
+        [undefined, 1],
+        [null, 1],
+        [-5, 1],
+        [1, 1],
+        [5.6, 6],
+        [10, 10],
+        [11, 10],
+        [999, 10],
+        ['invalid', 1],
+    ];
+
+    for (const [value, expected] of cases) {
+        const serialized = value === undefined ? 'undefined' : JSON.stringify(value);
+        assert.equal(evaluateProgression(`clampCurseLevel(${serialized})`), expected);
+    }
+});
+
+test('equipment levels remain bounded between 1 and 100', () => {
+    const cases = [
+        [undefined, 1],
+        [-5, 1],
+        [1, 1],
+        [50.6, 51],
+        [100, 100],
+        [101, 100],
+    ];
+
+    for (const [value, expected] of cases) {
+        const serialized = value === undefined ? 'undefined' : JSON.stringify(value);
+        assert.equal(evaluateProgression(`clampEquipmentLevel(${serialized})`), expected);
+    }
+});
+
+test('progression limits load before scripts that consume them', () => {
+    const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+    const progressionIndex = html.indexOf('assets/js/progression.js');
+
+    assert.ok(progressionIndex >= 0);
+    for (const script of ['player.js', 'equipment.js', 'forge.js', 'companion.js', 'dungeon.js', 'main.js']) {
+        assert.ok(progressionIndex < html.indexOf(`assets/js/${script}`), `${script} must load after progression.js`);
+    }
+});


### PR DESCRIPTION
## Summary

- add shared constants for the active Curse and equipment level limits
- centralize Curse and equipment level normalization
- replace scattered hard-coded caps without changing current gameplay
- add Node regression tests for old/malformed save values and script loading order

## Active limits

- standard Curse maximum: 10
- active Curse maximum: 10
- equipment level maximum: 100

`MAX_CURSE_LEVEL` intentionally remains 10 in this preparatory package. A later package can raise it to 15 together with the new unlock rules.

## Verification

- `node --check` for all files in `assets/js/` and `tests/`
- `node --test tests/progression-limits.test.js`
- `git diff --check`
- browser smoke test with no JavaScript console errors