### PR TITLE
feat: gate higher Curse unlocks behind Monarch

### DIFF
--- a/assets/js/combat.js
+++ b/assets/js/combat.js
@@ -1084,6 +1084,9 @@ const bindRunSummaryButton = () => {
 };
 
 const handleSpecialBossVictory = () => {
+    if (typeof maybeUnlockNextCurseLevel === 'function') {
+        maybeUnlockNextCurseLevel(CURSE_UNLOCK_TRIGGER_MONARCH);
+    }
     pendingRunSummary = createRunSummary('victory');
     runSummaryReadyInCombat = true;
     addCombatLog(t('combat-victory-monarch-defeated'));

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1118,39 +1118,37 @@ const saveData = () => {
     }
 }
 
-const maybeUnlockNextCurseLevel = () => {
+const maybeUnlockNextCurseLevel = (trigger = CURSE_UNLOCK_TRIGGER_FLOOR) => {
     if (!player || !dungeon || !dungeon.progress || !dungeon.settings) {
-        return;
+        return false;
     }
     if (typeof player.maxUnlockedCurseLevel !== "number") {
-        player.maxUnlockedCurseLevel = 1;
+        player.maxUnlockedCurseLevel = MIN_CURSE_LEVEL;
     }
     player.maxUnlockedCurseLevel = clampCurseLevel(player.maxUnlockedCurseLevel);
-    const maxUnlocked = player.maxUnlockedCurseLevel;
-    if (maxUnlocked >= MAX_CURSE_LEVEL) {
-        return;
+    const newMax = getNextCurseUnlockLevel({
+        maxUnlockedCurseLevel: player.maxUnlockedCurseLevel,
+        selectedCurseLevel: player.selectedCurseLevel,
+        floor: dungeon.progress.floor,
+        trigger,
+    });
+    if (newMax === null) {
+        return false;
     }
-    const selectedLevel = clampCurseLevel(player.selectedCurseLevel || 1);
-    if (selectedLevel !== maxUnlocked) {
-        return;
+
+    player.maxUnlockedCurseLevel = newMax;
+    if (typeof ensureRunStatisticsShape === 'function') {
+        ensureRunStatisticsShape();
     }
-    if (dungeon.progress.floor >= 10) {
-        const newMax = clampCurseLevel(maxUnlocked + 1);
-        if (newMax > player.maxUnlockedCurseLevel) {
-            player.maxUnlockedCurseLevel = newMax;
-            if (typeof ensureRunStatisticsShape === 'function') {
-                ensureRunStatisticsShape();
-            }
-            if (dungeon && dungeon.statistics) {
-                dungeon.statistics.latestCurseUnlock = newMax;
-            }
-            if (typeof addDungeonLog === 'function') {
-                const unlockMessage = t('curse-level-unlocked', { level: newMax });
-                addDungeonLog(`<span class="CurseUnlock">${unlockMessage}</span>`);
-            }
-            saveData();
-        }
+    if (dungeon && dungeon.statistics) {
+        dungeon.statistics.latestCurseUnlock = newMax;
     }
+    if (typeof addDungeonLog === 'function') {
+        const unlockMessage = t('curse-level-unlocked', { level: newMax });
+        addDungeonLog(`<span class="CurseUnlock">${unlockMessage}</span>`);
+    }
+    saveData();
+    return true;
 };
 
 if (typeof window !== 'undefined') {

--- a/assets/js/progression.js
+++ b/assets/js/progression.js
@@ -2,6 +2,9 @@ const MIN_CURSE_LEVEL = 1;
 const MAX_STANDARD_CURSE_LEVEL = 10;
 const MAX_CURSE_LEVEL = MAX_STANDARD_CURSE_LEVEL;
 const MAX_EQUIPMENT_LEVEL = 100;
+const STANDARD_CURSE_UNLOCK_FLOOR = 10;
+const CURSE_UNLOCK_TRIGGER_FLOOR = 'floor';
+const CURSE_UNLOCK_TRIGGER_MONARCH = 'monarch';
 
 const clampCurseLevel = (value) => {
     let level = Number(value);
@@ -19,4 +22,29 @@ const clampEquipmentLevel = (value) => {
     }
     level = Math.round(level);
     return Math.min(MAX_EQUIPMENT_LEVEL, Math.max(1, level));
+};
+
+const getNextCurseUnlockLevel = ({
+    maxUnlockedCurseLevel,
+    selectedCurseLevel,
+    floor,
+    trigger = CURSE_UNLOCK_TRIGGER_FLOOR,
+    maxCurseLevel = MAX_CURSE_LEVEL,
+}) => {
+    const normalizedMaximum = Math.max(MIN_CURSE_LEVEL, Math.round(Number(maxCurseLevel)) || MIN_CURSE_LEVEL);
+    const maxUnlocked = Math.min(normalizedMaximum, Math.max(MIN_CURSE_LEVEL, Math.round(Number(maxUnlockedCurseLevel)) || MIN_CURSE_LEVEL));
+    const selectedLevel = Math.min(normalizedMaximum, Math.max(MIN_CURSE_LEVEL, Math.round(Number(selectedCurseLevel)) || MIN_CURSE_LEVEL));
+
+    if (maxUnlocked >= normalizedMaximum || selectedLevel !== maxUnlocked) {
+        return null;
+    }
+
+    const requiresMonarchVictory = maxUnlocked >= MAX_STANDARD_CURSE_LEVEL;
+    if (requiresMonarchVictory) {
+        return trigger === CURSE_UNLOCK_TRIGGER_MONARCH ? maxUnlocked + 1 : null;
+    }
+
+    return Number(floor) >= STANDARD_CURSE_UNLOCK_FLOOR && trigger === CURSE_UNLOCK_TRIGGER_FLOOR
+        ? maxUnlocked + 1
+        : null;
 };

--- a/tests/monarch-curse-unlocks.test.js
+++ b/tests/monarch-curse-unlocks.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const progressionSource = fs.readFileSync(path.join(root, 'assets/js/progression.js'), 'utf8');
+
+const getNextUnlock = (state) => {
+    const context = vm.createContext({ state });
+    vm.runInContext(progressionSource, context);
+    return vm.runInContext('getNextCurseUnlockLevel(state)', context);
+};
+
+const futureState = (overrides = {}) => ({
+    maxUnlockedCurseLevel: 10,
+    selectedCurseLevel: 10,
+    floor: 20,
+    trigger: 'floor',
+    maxCurseLevel: 15,
+    ...overrides,
+});
+
+test('Curse 1 through 10 keep the Floor 10 unlock rule', () => {
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 9,
+        selectedCurseLevel: 9,
+        floor: 9,
+    })), null);
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 9,
+        selectedCurseLevel: 9,
+        floor: 10,
+    })), 10);
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 9,
+        selectedCurseLevel: 9,
+        trigger: 'monarch',
+    })), null);
+});
+
+test('reaching Floor 10 or higher cannot unlock Curse 11 and above', () => {
+    assert.equal(getNextUnlock(futureState({ floor: 10 })), null);
+    assert.equal(getNextUnlock(futureState({ floor: 100 })), null);
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 11,
+        selectedCurseLevel: 11,
+        floor: 100,
+    })), null);
+});
+
+test('a Monarch victory unlocks exactly one level from Curse 10 onward', () => {
+    assert.equal(getNextUnlock(futureState({ trigger: 'monarch' })), 11);
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 11,
+        selectedCurseLevel: 11,
+        trigger: 'monarch',
+    })), 12);
+});
+
+test('Monarch victories only count on the highest unlocked Curse Level', () => {
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 11,
+        selectedCurseLevel: 10,
+        trigger: 'monarch',
+    })), null);
+    assert.equal(getNextUnlock(futureState({
+        maxUnlockedCurseLevel: 15,
+        selectedCurseLevel: 15,
+        trigger: 'monarch',
+    })), null);
+});
+
+test('the active Curse 10 cap remains unchanged until the expansion package', () => {
+    assert.equal(getNextUnlock({
+        maxUnlockedCurseLevel: 10,
+        selectedCurseLevel: 10,
+        floor: 20,
+        trigger: 'monarch',
+    }), null);
+});
+
+test('the Monarch unlock runs before the victory summary is created', () => {
+    const combatSource = fs.readFileSync(path.join(root, 'assets/js/combat.js'), 'utf8');
+    const handlerStart = combatSource.indexOf('const handleSpecialBossVictory');
+    const unlockCall = combatSource.indexOf('maybeUnlockNextCurseLevel(CURSE_UNLOCK_TRIGGER_MONARCH)', handlerStart);
+    const summaryCall = combatSource.indexOf("createRunSummary('victory')", handlerStart);
+
+    assert.ok(handlerStart >= 0);
+    assert.ok(unlockCall > handlerStart);
+    assert.ok(summaryCall > unlockCall);
+});


### PR DESCRIPTION
## Summary

- preserve Floor 10 unlocks for Curse Levels 1 through 10
- require a Dungeon Monarch victory to unlock each level above Curse 10
- only allow progression while playing the highest unlocked Curse Level
- apply the Monarch unlock before creating the victory summary
- add regression tests for Floor, Monarch, repeat-victory, lower-Curse, and maximum-cap cases

## Package boundary

The active `MAX_CURSE_LEVEL` intentionally remains 10 in this package. The rule is implemented and tested against the planned cap of 15, but becomes player-visible when the following Curse selection/persistence package raises the active cap. This keeps the current release behavior complete while landing the unlock rule separately.

## Verification

- `node --check` for all files in `assets/js/` and `tests/`
- `node --test tests/progression-limits.test.js tests/monarch-curse-unlocks.test.js` (10/10 passing)
- `git diff --check`
- browser smoke test and browser truth table
- no JavaScript console errors