### PR TITLE
feat: extend Curse selection to 15

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1630,6 +1630,7 @@ const importData = (importedData) => {
     try {
         let playerImport = JSON.parse(atob(importedData));
         if (playerImport.inventory !== undefined) {
+            normalizePlayerCurseProgress(playerImport);
             if (typeof normalizePermanentCompanionUnlockProgress === 'function') {
                 playerImport.permanentCompanionUnlockProgress = normalizePermanentCompanionUnlockProgress(playerImport.permanentCompanionUnlockProgress);
             }
@@ -1800,16 +1801,7 @@ const allocationPopup = () => {
             <div class="row">
                 <p data-i18n="curse">Curse</p>
                 <select id="select-curse">
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                    <option value="4">4</option>
-                    <option value="5">5</option>
-                    <option value="6">6</option>
-                    <option value="7">7</option>
-                    <option value="8">8</option>
-                    <option value="9">9</option>
-                    <option value="10">10</option>
+                    ${getCurseLevelRange().map((level) => `<option value="${level}">${level}</option>`).join('')}
                 </select>
             </div>
             <div class="row" id="forge-button-row" style="margin-top: 15px">

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -49,34 +49,22 @@ if (player) {
     if (player.companionCharm === undefined) {
         player.companionCharm = null;
     }
-    if (player.maxUnlockedCurseLevel === undefined) {
-        player.maxUnlockedCurseLevel = 1;
-    }
-    player.maxUnlockedCurseLevel = clampCurseLevel(player.maxUnlockedCurseLevel);
     if (player.selectedCurseLevel === undefined) {
         const savedDungeon = safeLoad(STORAGE_KEYS.dungeon, STORAGE_KEYS.dungeonBackup);
         if (savedDungeon) {
             try {
-                const parsedDungeon = JSON.parse(savedDungeon);
-                if (parsedDungeon && parsedDungeon.settings && Number.isFinite(parsedDungeon.settings.enemyScaling)) {
-                    const inferredLevel = clampCurseLevel(Math.round((parsedDungeon.settings.enemyScaling - 1) * 10));
-                    player.selectedCurseLevel = inferredLevel;
+                const parsedDungeon = typeof savedDungeon === 'string'
+                    ? JSON.parse(savedDungeon)
+                    : savedDungeon;
+                if (parsedDungeon.settings && Number.isFinite(parsedDungeon.settings.enemyScaling)) {
+                    player.selectedCurseLevel = Math.round((parsedDungeon.settings.enemyScaling - 1) * 10);
                 }
             } catch (err) {
-                player.selectedCurseLevel = 1;
+                player.selectedCurseLevel = MIN_CURSE_LEVEL;
             }
         }
     }
-    if (player.selectedCurseLevel === undefined) {
-        player.selectedCurseLevel = 1;
-    }
-    player.selectedCurseLevel = clampCurseLevel(player.selectedCurseLevel);
-    if (player.selectedCurseLevel > player.maxUnlockedCurseLevel) {
-        player.maxUnlockedCurseLevel = player.selectedCurseLevel;
-    }
-    if (player.selectedCurseLevel > player.maxUnlockedCurseLevel) {
-        player.selectedCurseLevel = player.maxUnlockedCurseLevel;
-    }
+    normalizePlayerCurseProgress(player);
 }
 
 let inventoryOpen = false;

--- a/assets/js/progression.js
+++ b/assets/js/progression.js
@@ -1,6 +1,6 @@
 const MIN_CURSE_LEVEL = 1;
 const MAX_STANDARD_CURSE_LEVEL = 10;
-const MAX_CURSE_LEVEL = MAX_STANDARD_CURSE_LEVEL;
+const MAX_CURSE_LEVEL = 15;
 const MAX_EQUIPMENT_LEVEL = 100;
 const STANDARD_CURSE_UNLOCK_FLOOR = 10;
 const CURSE_UNLOCK_TRIGGER_FLOOR = 'floor';
@@ -15,6 +15,26 @@ const clampCurseLevel = (value) => {
     return Math.min(MAX_CURSE_LEVEL, Math.max(MIN_CURSE_LEVEL, level));
 };
 
+const normalizePlayerCurseProgress = (playerData) => {
+    if (!playerData || typeof playerData !== 'object') {
+        return playerData;
+    }
+
+    const rawMaximum = playerData.maxUnlockedCurseLevel;
+    const hasSavedMaximum = rawMaximum !== undefined
+        && rawMaximum !== null
+        && rawMaximum !== ''
+        && Number.isFinite(Number(rawMaximum));
+    const selectedLevel = clampCurseLevel(playerData.selectedCurseLevel);
+    const maxUnlockedLevel = hasSavedMaximum
+        ? clampCurseLevel(rawMaximum)
+        : selectedLevel;
+
+    playerData.maxUnlockedCurseLevel = maxUnlockedLevel;
+    playerData.selectedCurseLevel = Math.min(selectedLevel, maxUnlockedLevel);
+    return playerData;
+};
+
 const clampEquipmentLevel = (value) => {
     let level = Number(value);
     if (!Number.isFinite(level)) {
@@ -23,6 +43,11 @@ const clampEquipmentLevel = (value) => {
     level = Math.round(level);
     return Math.min(MAX_EQUIPMENT_LEVEL, Math.max(1, level));
 };
+
+const getCurseLevelRange = () => Array.from(
+    { length: MAX_CURSE_LEVEL - MIN_CURSE_LEVEL + 1 },
+    (_, index) => index + MIN_CURSE_LEVEL,
+);
 
 const getNextCurseUnlockLevel = ({
     maxUnlockedCurseLevel,

--- a/tests/monarch-curse-unlocks.test.js
+++ b/tests/monarch-curse-unlocks.test.js
@@ -13,27 +13,26 @@ const getNextUnlock = (state) => {
     return vm.runInContext('getNextCurseUnlockLevel(state)', context);
 };
 
-const futureState = (overrides = {}) => ({
+const activeState = (overrides = {}) => ({
     maxUnlockedCurseLevel: 10,
     selectedCurseLevel: 10,
     floor: 20,
     trigger: 'floor',
-    maxCurseLevel: 15,
     ...overrides,
 });
 
 test('Curse 1 through 10 keep the Floor 10 unlock rule', () => {
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 9,
         selectedCurseLevel: 9,
         floor: 9,
     })), null);
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 9,
         selectedCurseLevel: 9,
         floor: 10,
     })), 10);
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 9,
         selectedCurseLevel: 9,
         trigger: 'monarch',
@@ -41,9 +40,9 @@ test('Curse 1 through 10 keep the Floor 10 unlock rule', () => {
 });
 
 test('reaching Floor 10 or higher cannot unlock Curse 11 and above', () => {
-    assert.equal(getNextUnlock(futureState({ floor: 10 })), null);
-    assert.equal(getNextUnlock(futureState({ floor: 100 })), null);
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({ floor: 10 })), null);
+    assert.equal(getNextUnlock(activeState({ floor: 100 })), null);
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 11,
         selectedCurseLevel: 11,
         floor: 100,
@@ -51,8 +50,8 @@ test('reaching Floor 10 or higher cannot unlock Curse 11 and above', () => {
 });
 
 test('a Monarch victory unlocks exactly one level from Curse 10 onward', () => {
-    assert.equal(getNextUnlock(futureState({ trigger: 'monarch' })), 11);
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({ trigger: 'monarch' })), 11);
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 11,
         selectedCurseLevel: 11,
         trigger: 'monarch',
@@ -60,25 +59,25 @@ test('a Monarch victory unlocks exactly one level from Curse 10 onward', () => {
 });
 
 test('Monarch victories only count on the highest unlocked Curse Level', () => {
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 11,
         selectedCurseLevel: 10,
         trigger: 'monarch',
     })), null);
-    assert.equal(getNextUnlock(futureState({
+    assert.equal(getNextUnlock(activeState({
         maxUnlockedCurseLevel: 15,
         selectedCurseLevel: 15,
         trigger: 'monarch',
     })), null);
 });
 
-test('the active Curse 10 cap remains unchanged until the expansion package', () => {
+test('the active Curse cap allows Monarch progression from 10 to 11', () => {
     assert.equal(getNextUnlock({
         maxUnlockedCurseLevel: 10,
         selectedCurseLevel: 10,
         floor: 20,
         trigger: 'monarch',
-    }), null);
+    }), 11);
 });
 
 test('the Monarch unlock runs before the victory summary is created', () => {

--- a/tests/progression-limits.test.js
+++ b/tests/progression-limits.test.js
@@ -13,7 +13,7 @@ const evaluateProgression = (expression) => {
     return vm.runInContext(expression, context);
 };
 
-test('active progression limits preserve the current gameplay caps', () => {
+test('active progression limits expose Curse 15 while keeping standard Curse and equipment caps', () => {
     const limits = evaluateProgression(`({
         minCurse: MIN_CURSE_LEVEL,
         maxStandardCurse: MAX_STANDARD_CURSE_LEVEL,
@@ -23,11 +23,11 @@ test('active progression limits preserve the current gameplay caps', () => {
 
     assert.deepEqual(
         JSON.parse(JSON.stringify(limits)),
-        { minCurse: 1, maxStandardCurse: 10, maxCurse: 10, maxEquipment: 100 },
+        { minCurse: 1, maxStandardCurse: 10, maxCurse: 15, maxEquipment: 100 },
     );
 });
 
-test('curse values from old or malformed saves are normalized as before', () => {
+test('curse values from old or malformed saves are normalized between 1 and 15', () => {
     const cases = [
         [undefined, 1],
         [null, 1],
@@ -35,8 +35,9 @@ test('curse values from old or malformed saves are normalized as before', () => 
         [1, 1],
         [5.6, 6],
         [10, 10],
-        [11, 10],
-        [999, 10],
+        [11, 11],
+        [15, 15],
+        [999, 15],
         ['invalid', 1],
     ];
 
@@ -44,6 +45,26 @@ test('curse values from old or malformed saves are normalized as before', () => 
         const serialized = value === undefined ? 'undefined' : JSON.stringify(value);
         assert.equal(evaluateProgression(`clampCurseLevel(${serialized})`), expected);
     }
+});
+
+test('player Curse progress preserves old saves and enforces unlocked selections', () => {
+    const cases = [
+        [{ maxUnlockedCurseLevel: 10, selectedCurseLevel: 10 }, { maxUnlockedCurseLevel: 10, selectedCurseLevel: 10 }],
+        [{ maxUnlockedCurseLevel: 12, selectedCurseLevel: 11 }, { maxUnlockedCurseLevel: 12, selectedCurseLevel: 11 }],
+        [{ selectedCurseLevel: 10 }, { maxUnlockedCurseLevel: 10, selectedCurseLevel: 10 }],
+        [{ maxUnlockedCurseLevel: 10, selectedCurseLevel: 15 }, { maxUnlockedCurseLevel: 10, selectedCurseLevel: 10 }],
+        [{ maxUnlockedCurseLevel: 99, selectedCurseLevel: 99 }, { maxUnlockedCurseLevel: 15, selectedCurseLevel: 15 }],
+    ];
+
+    for (const [input, expected] of cases) {
+        const actual = evaluateProgression(`normalizePlayerCurseProgress(${JSON.stringify(input)})`);
+        assert.deepEqual(JSON.parse(JSON.stringify(actual)), expected);
+    }
+});
+
+test('Curse selection contains every level from 1 through 15', () => {
+    const levels = evaluateProgression('getCurseLevelRange()');
+    assert.deepEqual(JSON.parse(JSON.stringify(levels)), Array.from({ length: 15 }, (_, index) => index + 1));
 });
 
 test('equipment levels remain bounded between 1 and 100', () => {


### PR DESCRIPTION
## Summary

- raise the active Curse cap from 10 to 15
- generate the Curse selector from the shared progression limits
- keep locked levels disabled until they are unlocked
- normalize Curse progress when loading and importing saves
- preserve legacy saves that only stored the selected Curse Level
- prevent a selected level from exceeding the saved unlocked maximum
- activate the Monarch progression rule from the previous package

## Behavior

- old Curse 10 saves remain at Curse 10
- Curse 11-15 are persisted and restored
- malformed values are clamped to 1-15
- Floor 10 cannot unlock Curse 11+
- each Monarch victory on the highest unlocked Curse unlocks exactly one next level

## Verification

- `node --check` for all files in `assets/js/` and `tests/`
- `node --test tests/progression-limits.test.js tests/monarch-curse-unlocks.test.js` (12/12 passing)
- `git diff --check`
- browser test: 15 options rendered; with maximum 12, levels 1-12 enabled and 13-15 disabled
- browser save/reload test preserved maximum 12 and selected level 11
- no JavaScript console errors

## Follow-up

Equipment generation is still capped at Tier 10. The next package will add matching equipment tiers 11-15.