### PR TITLE
feat: extend equipment tiers to 15

### DIFF
--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -261,11 +261,7 @@ const createEquipment = (addToInventory = true, options = {}) => {
             equipment.rarity = minRarity;
         }
     }
-    let enemyScaling = dungeon.settings.enemyScaling;
-    if (enemyScaling > 2) {
-        enemyScaling = 2;
-    }
-    equipment.tier = Math.round((enemyScaling - 1) * 10);
+    equipment.tier = getEquipmentTierFromEnemyScaling(dungeon.settings.enemyScaling);
     rerollEquipmentStats(equipment);
     if (addToInventory) {
         if (isCompanionCharm(equipment) && !player.companionCharm) {
@@ -348,10 +344,8 @@ const getEquipmentRerollStatPool = (equipment) => {
 };
 
 const rerollEquipmentStats = (equipment) => {
-    let enemyScaling = 1 + (equipment.tier / 10);
-    if (enemyScaling > 2) {
-        enemyScaling = 2;
-    }
+    equipment.tier = clampEquipmentTier(equipment.tier);
+    const enemyScaling = getEnemyScalingFromEquipmentTier(equipment.tier);
     if (isCompanionCharm(equipment)) {
         rerollCompanionCharmStats(equipment, enemyScaling);
         return;

--- a/assets/js/progression.js
+++ b/assets/js/progression.js
@@ -2,6 +2,9 @@ const MIN_CURSE_LEVEL = 1;
 const MAX_STANDARD_CURSE_LEVEL = 10;
 const MAX_CURSE_LEVEL = 15;
 const MAX_EQUIPMENT_LEVEL = 100;
+const MIN_EQUIPMENT_TIER = 1;
+const MAX_EQUIPMENT_TIER = MAX_CURSE_LEVEL;
+const EQUIPMENT_TIER_SCALING_FACTOR = 10;
 const STANDARD_CURSE_UNLOCK_FLOOR = 10;
 const CURSE_UNLOCK_TRIGGER_FLOOR = 'floor';
 const CURSE_UNLOCK_TRIGGER_MONARCH = 'monarch';
@@ -43,6 +46,27 @@ const clampEquipmentLevel = (value) => {
     level = Math.round(level);
     return Math.min(MAX_EQUIPMENT_LEVEL, Math.max(1, level));
 };
+
+const clampEquipmentTier = (value) => {
+    let tier = Number(value);
+    if (!Number.isFinite(tier)) {
+        tier = MIN_EQUIPMENT_TIER;
+    }
+    tier = Math.round(tier);
+    return Math.min(MAX_EQUIPMENT_TIER, Math.max(MIN_EQUIPMENT_TIER, tier));
+};
+
+const getEquipmentTierFromEnemyScaling = (enemyScaling) => {
+    const scaling = Number(enemyScaling);
+    if (!Number.isFinite(scaling)) {
+        return MIN_EQUIPMENT_TIER;
+    }
+    return clampEquipmentTier((scaling - 1) * EQUIPMENT_TIER_SCALING_FACTOR);
+};
+
+const getEnemyScalingFromEquipmentTier = (tier) => (
+    1 + (clampEquipmentTier(tier) / EQUIPMENT_TIER_SCALING_FACTOR)
+);
 
 const getCurseLevelRange = () => Array.from(
     { length: MAX_CURSE_LEVEL - MIN_CURSE_LEVEL + 1 },

--- a/tests/equipment-tiers.test.js
+++ b/tests/equipment-tiers.test.js
@@ -1,0 +1,96 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const progressionSource = fs.readFileSync(path.join(root, 'assets/js/progression.js'), 'utf8');
+
+const evaluateProgression = (expression) => {
+    const context = vm.createContext({});
+    vm.runInContext(progressionSource, context);
+    return vm.runInContext(expression, context);
+};
+
+test('equipment tiers span 1 through 15 while item levels remain capped at 100', () => {
+    const limits = evaluateProgression(`({
+        minTier: MIN_EQUIPMENT_TIER,
+        maxTier: MAX_EQUIPMENT_TIER,
+        maxLevel: MAX_EQUIPMENT_LEVEL,
+    })`);
+
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(limits)),
+        { minTier: 1, maxTier: 15, maxLevel: 100 },
+    );
+});
+
+test('equipment tier values are normalized between 1 and 15', () => {
+    const cases = [
+        [undefined, 1],
+        ['invalid', 1],
+        [-5, 1],
+        [1, 1],
+        [10, 10],
+        [11, 11],
+        [15, 15],
+        [99, 15],
+    ];
+
+    for (const [value, expected] of cases) {
+        const serialized = value === undefined ? 'undefined' : JSON.stringify(value);
+        assert.equal(evaluateProgression(`clampEquipmentTier(${serialized})`), expected);
+    }
+});
+
+test('Curse enemy scaling maps to matching equipment tiers through Tier 15', () => {
+    const cases = [
+        [1.1, 1],
+        [2, 10],
+        [2.1, 11],
+        [2.2, 12],
+        [2.5, 15],
+        [3, 15],
+    ];
+
+    for (const [scaling, expectedTier] of cases) {
+        assert.equal(evaluateProgression(`getEquipmentTierFromEnemyScaling(${scaling})`), expectedTier);
+    }
+});
+
+test('equipment tiers use their matching enemy scaling during stat rolls', () => {
+    const cases = [
+        [1, 1.1],
+        [10, 2],
+        [11, 2.1],
+        [12, 2.2],
+        [15, 2.5],
+        [99, 2.5],
+    ];
+
+    for (const [tier, expectedScaling] of cases) {
+        assert.equal(evaluateProgression(`getEnemyScalingFromEquipmentTier(${tier})`), expectedScaling);
+    }
+});
+
+test('every supported equipment tier round-trips through enemy scaling', () => {
+    for (let tier = 1; tier <= 15; tier++) {
+        assert.equal(
+            evaluateProgression(`getEquipmentTierFromEnemyScaling(getEnemyScalingFromEquipmentTier(${tier}))`),
+            tier,
+        );
+    }
+});
+
+test('equipment generation, rerolls, and forging consume the shared tier limits', () => {
+    const equipmentSource = fs.readFileSync(path.join(root, 'assets/js/equipment.js'), 'utf8');
+    const forgeSource = fs.readFileSync(path.join(root, 'assets/js/forge.js'), 'utf8');
+
+    assert.match(equipmentSource, /equipment\.tier = getEquipmentTierFromEnemyScaling\(dungeon\.settings\.enemyScaling\)/);
+    assert.match(equipmentSource, /equipment\.tier = clampEquipmentTier\(equipment\.tier\)/);
+    assert.match(equipmentSource, /getEnemyScalingFromEquipmentTier\(equipment\.tier\)/);
+    assert.doesNotMatch(equipmentSource, /enemyScaling > 2/);
+    assert.match(forgeSource, /forgedEquipment\.tier = item1\.tier/);
+    assert.match(forgeSource, /const maxLvl = clampEquipmentLevel\(avgLvl \+ 2\)/);
+});


### PR DESCRIPTION
## Summary

- add centralized equipment tier limits from Tier 1 through Tier 15
- map Curse enemy scaling 2.1-2.5 to Equipment Tiers 11-15
- let higher tiers use their matching scaling during stat rolls and rerolls
- preserve the existing maximum item level of 100
- normalize missing, invalid, and out-of-range tiers to 1-15
- keep Forge results on the same tier as their input items

## Behavior

- Curse 10 continues to drop Tier 10 equipment
- Curse 11 drops Tier 11 equipment, continuing through Curse 15 / Tier 15
- Tier 10 legacy items remain Tier 10 when rerolled
- legacy items without a tier normalize to Tier 1 when rerolled
- forged Tier 15 items remain Tier 15 and cannot exceed Level 100

## Verification

- `node --check` for all files in `assets/js/` and `tests/`
- `node --test tests/*.test.js` (18/18 passing)
- `git diff --check`
- browser drop test: Curse 11 -> Tier 11, Curse 15 -> Tier 15
- browser Forge test: three Tier 15 Level 100 items -> Tier 15 Level 100 result
- browser legacy test: Tier 10 remains 10, missing tier normalizes to 1, Tier 99 clamps to 15
- no JavaScript console errors

## Follow-up

This package extends the existing linear stat scaling. Dedicated balance tuning for Curse and Equipment Tiers 11-15 remains a separate follow-up.