### PR TITLE
fix: keep endgame scaling aligned

### DIFF
--- a/assets/js/companion.js
+++ b/assets/js/companion.js
@@ -562,7 +562,7 @@ function getPermanentCompanionFindCredit() {
     if (typeof player !== 'undefined' && player && Number.isFinite(Number(player.selectedCurseLevel))) {
         curseLevel = Number(player.selectedCurseLevel);
     } else if (typeof dungeon !== 'undefined' && dungeon && dungeon.settings && Number.isFinite(Number(dungeon.settings.enemyScaling))) {
-        curseLevel = Math.round((Number(dungeon.settings.enemyScaling) - 1) * 10);
+        curseLevel = getCurseLevelFromEnemyScaling(dungeon.settings.enemyScaling);
     }
 
     return Math.max(MIN_CURSE_LEVEL, Math.min(MAX_STANDARD_CURSE_LEVEL, Math.round(curseLevel)));

--- a/assets/js/enemy.js
+++ b/assets/js/enemy.js
@@ -286,7 +286,7 @@ const setEnemyStats = (type, condition) => {
     enemy.stats.critDmg = enemy.stats.critDmg * dungeon.enemyMultipliers.critDmg;
 
     // Calculate dodge chance based on curse level and enemy level
-    let curseLvl = Math.round((dungeon.settings.enemyScaling - 1) * 10);
+    const curseLvl = getCurseLevelFromEnemyScaling(dungeon.settings.enemyScaling);
     enemy.stats.dodge = ((curseLvl - 1) * 2) + (enemy.lvl / 10);
     if (enemy.stats.dodge < 0) {
         enemy.stats.dodge = 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -553,7 +553,7 @@ function openMenu(isTitle = false) {
                     </div>
                     <p>${player.selectedClass} Lv.${player.lvl} (${player.skills})</p>
                     <p>${t('blessings')}: Lvl.${player.blessing}</p>
-                    <p>${t('curse')}: Lvl.${Math.round((dungeon.settings.enemyScaling - 1) * 10)}</p>
+                    <p>${t('curse')}: Lvl.${getCurseLevelFromEnemyScaling(dungeon.settings.enemyScaling)}</p>
                     <p>${t('kills')}: ${nFormatter(dungeon.statistics.kills)}</p>
                     <p>${t('runtime')}: ${runTime}</p>
                 </div>`;
@@ -1330,7 +1330,7 @@ const progressReset = (fromDeath = false) => {
         enemyBaseLvl: 1,
         enemyLvlGap: 5,
         enemyBaseStats: 1,
-        enemyScaling: 1 + (storedCurseLevel / 10),
+        enemyScaling: getEnemyScalingFromCurseLevel(storedCurseLevel),
     };
     dungeon.floorBuffs = {
         atk: 0,
@@ -1949,7 +1949,7 @@ const allocationPopup = () => {
         selectClass.onchange();
     
         let selectCurse = document.querySelector("#select-curse");
-        let defaultCurseLevel = clampCurseLevel(Math.round((dungeon.settings.enemyScaling - 1) * 10));
+        let defaultCurseLevel = getCurseLevelFromEnemyScaling(dungeon.settings.enemyScaling);
         if (player && typeof player.selectedCurseLevel === "number") {
             defaultCurseLevel = clampCurseLevel(player.selectedCurseLevel);
         }
@@ -2009,7 +2009,6 @@ const allocationPopup = () => {
             selectedCurseLevel = maxUnlockedCurse;
         }
         player.selectedCurseLevel = selectedCurseLevel;
-        dungeon.settings.enemyScaling = 1 + (selectedCurseLevel / 10);
         // Set player skill
         objectValidation();
         player.skills = [selectSkill.value];
@@ -2020,6 +2019,7 @@ const allocationPopup = () => {
         // Proceed to dungeon
         player.allocated = true;
         enterDungeon();
+        dungeon.settings.enemyScaling = getEnemyScalingFromCurseLevel(selectedCurseLevel);
         player.stats.hp = player.stats.hpMax;
         playerLoadStats();
         saveData();
@@ -2117,7 +2117,7 @@ const objectValidation = () => {
         changed = true;
     }
     if (dungeon && dungeon.settings) {
-        const desiredScaling = 1 + (player.selectedCurseLevel / 10);
+        const desiredScaling = getEnemyScalingFromCurseLevel(player.selectedCurseLevel);
         if (!Number.isFinite(dungeon.settings.enemyScaling) || Math.abs(dungeon.settings.enemyScaling - desiredScaling) > 0.0001) {
             dungeon.settings.enemyScaling = desiredScaling;
             changed = true;

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -57,7 +57,7 @@ if (player) {
                     ? JSON.parse(savedDungeon)
                     : savedDungeon;
                 if (parsedDungeon.settings && Number.isFinite(parsedDungeon.settings.enemyScaling)) {
-                    player.selectedCurseLevel = Math.round((parsedDungeon.settings.enemyScaling - 1) * 10);
+                    player.selectedCurseLevel = getCurseLevelFromEnemyScaling(parsedDungeon.settings.enemyScaling);
                 }
             } catch (err) {
                 player.selectedCurseLevel = MIN_CURSE_LEVEL;

--- a/assets/js/progression.js
+++ b/assets/js/progression.js
@@ -4,7 +4,7 @@ const MAX_CURSE_LEVEL = 15;
 const MAX_EQUIPMENT_LEVEL = 100;
 const MIN_EQUIPMENT_TIER = 1;
 const MAX_EQUIPMENT_TIER = MAX_CURSE_LEVEL;
-const EQUIPMENT_TIER_SCALING_FACTOR = 10;
+const PROGRESSION_SCALING_FACTOR = 10;
 const STANDARD_CURSE_UNLOCK_FLOOR = 10;
 const CURSE_UNLOCK_TRIGGER_FLOOR = 'floor';
 const CURSE_UNLOCK_TRIGGER_MONARCH = 'monarch';
@@ -16,6 +16,18 @@ const clampCurseLevel = (value) => {
     }
     level = Math.round(level);
     return Math.min(MAX_CURSE_LEVEL, Math.max(MIN_CURSE_LEVEL, level));
+};
+
+const getEnemyScalingFromCurseLevel = (curseLevel) => (
+    1 + (clampCurseLevel(curseLevel) / PROGRESSION_SCALING_FACTOR)
+);
+
+const getCurseLevelFromEnemyScaling = (enemyScaling) => {
+    const scaling = Number(enemyScaling);
+    if (!Number.isFinite(scaling)) {
+        return MIN_CURSE_LEVEL;
+    }
+    return clampCurseLevel((scaling - 1) * PROGRESSION_SCALING_FACTOR);
 };
 
 const normalizePlayerCurseProgress = (playerData) => {
@@ -56,16 +68,12 @@ const clampEquipmentTier = (value) => {
     return Math.min(MAX_EQUIPMENT_TIER, Math.max(MIN_EQUIPMENT_TIER, tier));
 };
 
-const getEquipmentTierFromEnemyScaling = (enemyScaling) => {
-    const scaling = Number(enemyScaling);
-    if (!Number.isFinite(scaling)) {
-        return MIN_EQUIPMENT_TIER;
-    }
-    return clampEquipmentTier((scaling - 1) * EQUIPMENT_TIER_SCALING_FACTOR);
-};
+const getEquipmentTierFromEnemyScaling = (enemyScaling) => (
+    clampEquipmentTier(getCurseLevelFromEnemyScaling(enemyScaling))
+);
 
 const getEnemyScalingFromEquipmentTier = (tier) => (
-    1 + (clampEquipmentTier(tier) / EQUIPMENT_TIER_SCALING_FACTOR)
+    1 + (clampEquipmentTier(tier) / PROGRESSION_SCALING_FACTOR)
 );
 
 const getCurseLevelRange = () => Array.from(

--- a/tests/endgame-balance.test.js
+++ b/tests/endgame-balance.test.js
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const progressionSource = fs.readFileSync(path.join(root, 'assets/js/progression.js'), 'utf8');
+
+const evaluateProgression = (expression) => {
+    const context = vm.createContext({});
+    vm.runInContext(progressionSource, context);
+    return vm.runInContext(expression, context);
+};
+
+test('Curse 1 through 10 retain their existing linear enemy scaling', () => {
+    for (let curseLevel = 1; curseLevel <= 10; curseLevel++) {
+        const expectedScaling = 1 + (curseLevel / 10);
+        assert.equal(
+            evaluateProgression(`getEnemyScalingFromCurseLevel(${curseLevel})`),
+            expectedScaling,
+        );
+    }
+});
+
+test('Curse 11 through 15 continue the same curve from 2.1 through 2.5', () => {
+    const expected = [2.1, 2.2, 2.3, 2.4, 2.5];
+    const actual = [11, 12, 13, 14, 15].map((curseLevel) => (
+        evaluateProgression(`getEnemyScalingFromCurseLevel(${curseLevel})`)
+    ));
+
+    assert.deepEqual(actual, expected);
+});
+
+test('Curse and enemy scaling round-trip for every supported level', () => {
+    for (let curseLevel = 1; curseLevel <= 15; curseLevel++) {
+        assert.equal(
+            evaluateProgression(`getCurseLevelFromEnemyScaling(getEnemyScalingFromCurseLevel(${curseLevel}))`),
+            curseLevel,
+        );
+    }
+});
+
+test('enemy and equipment progression use the same scaling at every Curse tier', () => {
+    for (let curseLevel = 1; curseLevel <= 15; curseLevel++) {
+        assert.equal(
+            evaluateProgression(`getEnemyScalingFromCurseLevel(${curseLevel})`),
+            evaluateProgression(`getEnemyScalingFromEquipmentTier(${curseLevel})`),
+        );
+    }
+
+    const enemySource = fs.readFileSync(path.join(root, 'assets/js/enemy.js'), 'utf8');
+    const equipmentSource = fs.readFileSync(path.join(root, 'assets/js/equipment.js'), 'utf8');
+    assert.match(enemySource, /\(dungeon\.settings\.enemyScaling - 1\) \* enemy\.lvl/);
+    assert.match(equipmentSource, /\(enemyScaling - 1\) \* equipment\.lvl/);
+});
+
+test('higher Curse tiers increase the linear level coefficient predictably', () => {
+    const level = 100;
+    const coefficients = [10, 11, 12, 13, 14, 15].map((curseLevel) => (
+        evaluateProgression(`Math.round((getEnemyScalingFromCurseLevel(${curseLevel}) - 1) * ${level})`)
+    ));
+
+    assert.deepEqual(coefficients, [100, 110, 120, 130, 140, 150]);
+});
+
+test('selected Curse scaling is restored after dungeon data loads', () => {
+    const mainSource = fs.readFileSync(path.join(root, 'assets/js/main.js'), 'utf8');
+    const allocationStart = mainSource.indexOf('const allocationPopup');
+    const enterDungeonCall = mainSource.indexOf('enterDungeon();', allocationStart);
+    const scalingAssignment = mainSource.indexOf(
+        'dungeon.settings.enemyScaling = getEnemyScalingFromCurseLevel(selectedCurseLevel);',
+        enterDungeonCall,
+    );
+    const saveCall = mainSource.indexOf('saveData();', scalingAssignment);
+
+    assert.ok(allocationStart >= 0);
+    assert.ok(enterDungeonCall > allocationStart);
+    assert.ok(scalingAssignment > enterDungeonCall);
+    assert.ok(saveCall > scalingAssignment);
+});
+
+test('Dungeon Monarch availability and encounter weight remain unchanged', () => {
+    const dungeonSource = fs.readFileSync(path.join(root, 'assets/js/dungeon.js'), 'utf8');
+
+    assert.match(dungeonSource, /if \(dungeon\.story\.phase >= 4\) \{\s*dungeon\.story\.monarchUnlocked = true;/);
+    assert.match(dungeonSource, /eventTypes\.push\("monarch", "monarch", "monarch"\);/);
+    assert.match(dungeonSource, /dungeon\.story\.monarchUnlocked && !dungeon\.story\.monarchSeen/);
+    assert.match(dungeonSource, /const specialBossBattle = \(\) => \{\s*dungeon\.story\.monarchSeen = true;/);
+});


### PR DESCRIPTION
## Summary

- centralize Curse Level ↔ enemy scaling conversion
- keep enemy and equipment progression on the same linear curve through Curse/Tier 15
- preserve all existing Curse 1-10 values
- continue Curse 11-15 from scaling 2.1 through 2.5 without adding arbitrary multipliers
- fix the selected Curse scaling being overwritten when dungeon save data loads during run start
- add regression coverage for the existing Dungeon Monarch availability and encounter weight

## Balance decision

The existing formulas already extrapolate consistently: enemy and equipment level coefficients both use `(scaling - 1) * level`. The package therefore keeps that balance instead of introducing untested extra multipliers. At Level 100, the coefficient progresses from 100 at Curse 10 to 150 at Curse 15 in equal steps.

## Monarch availability

No Monarch availability, unlock-floor, or encounter-weight code was changed. The existing three entries in the event pool remain intact.

## Verification

- `node --check` for all files in `assets/js/` and `tests/`
- `node --test tests/*.test.js` (27/27 passing)
- `git diff --check`
- confirmed `assets/js/dungeon.js` has no diff
- browser test: selecting Curse 15 now results in scaling 2.5 after dungeon data loads
- browser save check: scaling 2.5 is persisted
- browser drop check: Curse 15 produces Tier 15 Level 100 equipment
- no JavaScript console errors