### PR TITLE
hardening: restrict data-i18n-attr to safe attribute allowlist

### DIFF
--- a/assets/js/language.js
+++ b/assets/js/language.js
@@ -83,12 +83,13 @@ function applyTranslations(root = document) {
   });
 
   // Attributes (placeholder, title, aria-label, etc.)
+  const SAFE_ATTRS = new Set(['placeholder', 'title', 'aria-label', 'aria-placeholder', 'aria-description', 'alt', 'label']);
   root.querySelectorAll('[data-i18n-attr]').forEach(el => {
     // data-i18n-attr="placeholder:ui.search,title:ui.tooltip"
     const pairs = el.getAttribute('data-i18n-attr').split(',').map(s => s.trim());
     for (const pair of pairs) {
       const [attr, key] = pair.split(':').map(s => s.trim());
-      if (attr && key) el.setAttribute(attr, t(key));
+      if (attr && key && SAFE_ATTRS.has(attr)) el.setAttribute(attr, t(key));
     }
   });
 }

--- a/tests/i18n-attr-allowlist.test.js
+++ b/tests/i18n-attr-allowlist.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const languageSource = fs.readFileSync(path.join(root, 'assets/js/language.js'), 'utf8');
+
+// Expose applyTranslations and a dict-setter for testing
+const harness = `
+  globalThis._applyTranslations = applyTranslations;
+  globalThis._setDict = (lang, dict) => { dictionaries[lang] = dict; currentLanguage = lang; };
+`;
+
+function makeContext() {
+    const ctx = vm.createContext({
+        window: {},
+        localStorage: { getItem: () => null, setItem: () => {} },
+        navigator: { languages: ['en'], language: 'en' },
+        fetch: () => Promise.resolve({ json: () => Promise.resolve({}) }),
+        document: {
+            addEventListener() {},
+            documentElement: { lang: '' },
+            querySelectorAll: () => [],
+        },
+        performance: { now: () => 0 },
+        setTimeout: () => 0,
+        clearTimeout() {},
+    });
+    vm.runInContext(languageSource + harness, ctx);
+    ctx._setDict('en', { 'test-key': 'Search' });
+    return ctx;
+}
+
+function makeRoot(attrSpec) {
+    const attrs = {};
+    const el = {
+        getAttribute(name) {
+            if (name === 'data-i18n-attr') return attrSpec;
+            return null;
+        },
+        setAttribute(name, value) { attrs[name] = value; },
+        attrs,
+    };
+    return {
+        querySelectorAll(selector) {
+            if (selector === '[data-i18n]') return [];
+            if (selector === '[data-i18n-attr]') return [el];
+            return [];
+        },
+        el,
+    };
+}
+
+test('allowlisted attribute aria-label is translated', () => {
+    const ctx = makeContext();
+    const mockRoot = makeRoot('aria-label:test-key');
+    ctx._applyTranslations(mockRoot);
+
+    assert.equal(mockRoot.el.attrs['aria-label'], 'Search');
+});
+
+test('non-allowlisted attribute onclick is silently ignored', () => {
+    const ctx = makeContext();
+    const mockRoot = makeRoot('onclick:test-key');
+    ctx._applyTranslations(mockRoot);
+
+    assert.equal(mockRoot.el.attrs['onclick'], undefined);
+});


### PR DESCRIPTION
## Summary

Adds a `SAFE_ATTRS` allowlist to `applyTranslations()` in `assets/js/language.js` so that `data-i18n-attr` directives can only set a restricted set of HTML attributes (`placeholder`, `title`, `aria-label`, `aria-placeholder`, `aria-description`, `alt`, `label`). Attribute names outside this set are silently ignored.

## Characterization

This is **defense-in-depth hardening**, not a fix for a live vulnerability.

Attribute *names* come from our own application markup, not from locale JSON files — an attacker who can only influence translation *values* cannot introduce new attribute names via this code path. Additionally, `setAttribute()` does not re-parse a value string into additional attributes or event handlers, so even a malicious value could not inject an `onclick` handler through this path.

The allowlist nonetheless provides a useful safety rail: it ensures that even if markup is ever incorrectly authored with an event-handler attribute name, the i18n system will not pass a locale-controlled value through to it.

## Changes

- `assets/js/language.js`: guard `el.setAttribute()` with `SAFE_ATTRS.has(attr)` check

## Tests

- `tests/i18n-attr-allowlist.test.js`: two regression tests
  - `aria-label` (allowlisted) is correctly applied from the translation dictionary
  - `onclick` (non-allowlisted) is silently ignored

## Behaviour Preservation

All existing `data-i18n-attr` usages in the codebase target `aria-label`, which is in the allowlist. No existing functionality is affected.