### PR TITLE
Fix Auto Mode Level 100 auto-sell setting

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -791,7 +791,7 @@ function openMenu(isTitle = false) {
         const autoSellLevelOptions = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
         const autoSellBelowLevelSelected = Number.isNaN(autoSellBelowLevel)
             ? 0
-            : Math.max(0, Math.min(90, Math.floor(autoSellBelowLevel / 10) * 10));
+            : Math.max(0, Math.min(MAX_EQUIPMENT_LEVEL, Math.floor(autoSellBelowLevel / 10) * 10));
         const autoSellLevelOptionsMarkup = autoSellLevelOptions.map((value) => (
             `<option value="${value}" ${autoSellBelowLevelSelected === value ? 'selected' : ''}>${value}</option>`
         )).join('');

--- a/tests/auto-sell-level-setting.test.js
+++ b/tests/auto-sell-level-setting.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const progressionSource = fs.readFileSync(path.join(root, 'assets/js/progression.js'), 'utf8');
+const mainSource = fs.readFileSync(path.join(root, 'assets/js/main.js'), 'utf8');
+
+const maxEquipmentLevel = vm.runInNewContext(
+    `${progressionSource}\nMAX_EQUIPMENT_LEVEL`,
+);
+
+const selectionExpressionMatch = mainSource.match(
+    /const autoSellBelowLevelSelected = ([\s\S]*?);\n\s*const autoSellLevelOptionsMarkup/,
+);
+
+assert.ok(selectionExpressionMatch, 'auto-sell level selection expression should be present');
+
+const selectAutoSellLevel = (autoSellBelowLevel) => vm.runInNewContext(
+    `(${selectionExpressionMatch[1]})`,
+    { autoSellBelowLevel, MAX_EQUIPMENT_LEVEL: maxEquipmentLevel },
+);
+
+test('auto-sell settings preserve Level 100 as the selected threshold', () => {
+    assert.equal(maxEquipmentLevel, 100);
+    assert.equal(selectAutoSellLevel(100), 100);
+});
+
+test('auto-sell settings normalize invalid and out-of-range thresholds', () => {
+    assert.equal(selectAutoSellLevel(Number.NaN), 0);
+    assert.equal(selectAutoSellLevel(99), 90);
+    assert.equal(selectAutoSellLevel(110), 100);
+});
+
+test('auto-sell level options include the equipment level cap', () => {
+    assert.match(
+        mainSource,
+        /const autoSellLevelOptions = \[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100\]/,
+    );
+});


### PR DESCRIPTION
## Summary

- preserve `100` when reopening the Auto Mode auto-sell level setting
- replace the stale hard-coded `90` clamp with the shared `MAX_EQUIPMENT_LEVEL` limit
- add regression coverage for Level 100, invalid values, rounding, and the upper cap

Fixes the issue reported on Reddit: https://www.reddit.com/r/QuickDungeonCrawler/comments/1v9sdjq/autosell_below_level_100_bug/

## Verification

- syntax-checked every file in `assets/js/*.js` and `tests/*.js`
- validated all locale JSON files
- `node --test tests/*.test.js` — 43/43 passed
- browser round-trip: selected Level 100, applied, reopened Auto Mode settings, and confirmed Level 100 remained selected
- no browser console errors
- `git diff --check`