### PR TITLE
Fix missing stat names in the help modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,15 +186,15 @@
                     <p onclick="closeStatsModal()" aria-label="Close stats"><i class="fa fa-xmark"></i></p>
                 </div>
                 <div class="modal-body">
-                    <p><i class="fas fa-heart"></i><span data-i18n="stats-modal.health">Health points. When it reaches 0, you are defeated.</span></p>
-                    <p><i class="ra ra-sword"></i><span data-i18n="stats-modal.attack">Attack power that increases damage dealt.</span></p>
-                    <p><i class="ra ra-round-shield"></i><span data-i18n="stats-modal.defense">Defense that reduces damage taken.</span></p>
-                    <p><i class="ra ra-plain-dagger"></i><span data-i18n="stats-modal.attack-speed">Attacks per second; higher values make you attack faster.</span></p>
-                    <p><i class="ra ra-dripping-blade"></i><span data-i18n="stats-modal.vampirism">Percent of damage returned as health.</span></p>
-                    <p><i class="ra ra-lightning-bolt"></i><span data-i18n="stats-modal.crit-rate">Chance to land a critical hit.</span></p>
-                    <p><i class="ra ra-focused-lightning"></i><span data-i18n="stats-modal.crit-dmg">Bonus damage dealt on critical hits.</span></p>
-                    <p><i class="ra ra-player-dodge"></i><span data-i18n="stats-modal.dodge">Chance to evade incoming attacks.</span></p>
-                    <p><i class="ra ra-perspective-dice-one"></i><span data-i18n="stats-modal.luck">Increases equipment drop chance.</span></p>
+                    <p><i class="fas fa-heart"></i><strong data-i18n="stat-display.health">Health</strong>: <span data-i18n="stats-modal.health">Health points. When it reaches 0, you are defeated.</span></p>
+                    <p><i class="ra ra-sword"></i><strong data-i18n="stat-display.attack">Attack</strong>: <span data-i18n="stats-modal.attack">Attack power that increases damage dealt.</span></p>
+                    <p><i class="ra ra-round-shield"></i><strong data-i18n="stat-display.defense">Defense</strong>: <span data-i18n="stats-modal.defense">Defense that reduces damage taken.</span></p>
+                    <p><i class="ra ra-plain-dagger"></i><strong data-i18n="stat-display.attack-speed">Attack Speed</strong>: <span data-i18n="stats-modal.attack-speed">Attacks per second; higher values make you attack faster.</span></p>
+                    <p><i class="ra ra-dripping-blade"></i><strong data-i18n="stat-display.vampirism">Vampirism</strong>: <span data-i18n="stats-modal.vampirism">Percent of damage returned as health.</span></p>
+                    <p><i class="ra ra-lightning-bolt"></i><strong data-i18n="stat-display.crit-rate">Critical Rate</strong>: <span data-i18n="stats-modal.crit-rate">Chance to land a critical hit.</span></p>
+                    <p><i class="ra ra-focused-lightning"></i><strong data-i18n="stat-display.crit-dmg">Critical Damage</strong>: <span data-i18n="stats-modal.crit-dmg">Bonus damage dealt on critical hits.</span></p>
+                    <p><i class="ra ra-player-dodge"></i><strong data-i18n="stat-display.dodge">Dodge</strong>: <span data-i18n="stats-modal.dodge">Chance to evade incoming attacks.</span></p>
+                    <p><i class="ra ra-perspective-dice-one"></i><strong data-i18n="stat-display.luck">Luck</strong>: <span data-i18n="stats-modal.luck">Increases equipment drop chance.</span></p>
                     <p><strong data-i18n="stat-display.faster-run">Faster Run</strong>: <span data-i18n="stats-modal.faster-run-desc">Boot bonus that reduces time between dungeon events.</span></p>
                 </div>
             </div>

--- a/tests/stats-help-modal.test.js
+++ b/tests/stats-help-modal.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const indexSource = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const localeDirectory = path.join(root, 'assets/locales');
+
+const stats = [
+    ['health', 'health'],
+    ['attack', 'attack'],
+    ['defense', 'defense'],
+    ['attack-speed', 'attack-speed'],
+    ['vampirism', 'vampirism'],
+    ['crit-rate', 'crit-rate'],
+    ['crit-dmg', 'crit-dmg'],
+    ['dodge', 'dodge'],
+    ['luck', 'luck'],
+    ['faster-run', 'faster-run-desc'],
+];
+
+test('stats help modal gives every description an explicit translated name', () => {
+    for (const [displayKey, descriptionKey] of stats) {
+        const rowPattern = new RegExp(
+            `<strong data-i18n="stat-display\\.${displayKey}">[^<]+<\\/strong>:\\s*<span data-i18n="stats-modal\\.${descriptionKey}">`,
+        );
+        assert.match(indexSource, rowPattern, `${displayKey} should have a visible translated label`);
+    }
+});
+
+test('all locales provide the stats help labels and descriptions', () => {
+    const localeFiles = fs.readdirSync(localeDirectory).filter((file) => file.endsWith('.json'));
+    assert.ok(localeFiles.length > 0);
+
+    for (const file of localeFiles) {
+        const dictionary = JSON.parse(fs.readFileSync(path.join(localeDirectory, file), 'utf8'));
+        for (const [displayKey, descriptionKey] of stats) {
+            assert.equal(typeof dictionary['stat-display']?.[displayKey], 'string', `${file}: stat-display.${displayKey}`);
+            assert.equal(typeof dictionary['stats-modal']?.[descriptionKey], 'string', `${file}: stats-modal.${descriptionKey}`);
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- show an explicit translated stat name before every description in the Stats help modal
- reuse the existing `stat-display.*` translations, so no new locale strings are needed
- make Health, Attack, Defense, Attack Speed, Vampirism, Critical Rate, Critical Damage, Dodge, Luck, and Faster Run follow the same label-and-description structure
- add regression coverage for the modal markup and all supported locales

## Verification

- syntax-checked every file in `assets/js/*.js` and `tests/*.js`
- validated all locale JSON files
- `node --test tests/*.test.js` — 47/47 passed
- visually checked the German Stats modal in the browser
- confirmed all stat names are visible and the modal has no clipping or overlap
- no browser console errors
- `git diff --check`