### PR TITLE
Fix stats help modal opening sound

### DIFF
--- a/assets/js/utility.js
+++ b/assets/js/utility.js
@@ -297,8 +297,8 @@ function openStatsModal() {
     localStorage.setItem(STATS_HELP_SEEN_KEY, 'true');
     const statsHelpLink = document.getElementById('stats-help-link');
     if (statsHelpLink) statsHelpLink.classList.remove('hint-unseen');
-    if (typeof sfxConfirm !== 'undefined' && sfxConfirm && typeof sfxConfirm.play === 'function') {
-        sfxConfirm.play();
+    if (typeof sfxOpen !== 'undefined' && sfxOpen && typeof sfxOpen.play === 'function') {
+        sfxOpen.play();
     }
     statsModal.style.display = "flex";
     const dimDungeon = document.querySelector('#dungeon-main');


### PR DESCRIPTION
### Motivation
- Align the Stats help link behavior and audio with the Companion (summon) view so the same modal-open sound plays when the Stats help modal is opened.

### Description
- Use `sfxOpen.play()` instead of `sfxConfirm.play()` in `openStatsModal()` inside `assets/js/utility.js` so the Stats help link triggers the standard modal-open sound.

### Testing
- Ran `node --test tests/*.test.js` which completed with all tests passing (40/40) and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65b226a040832281d2f7d3531c1ec6)