### PR TITLE
feat: add typed equipment slots

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -285,6 +285,27 @@ color: black;
     position: relative;
 }
 
+.inventory-slot-badge {
+    position: absolute;
+    top: 50%;
+    right: 0.45rem;
+    padding: 0.12rem 0.35rem;
+    border: 1px solid rgba(130, 183, 218, 0.28);
+    border-radius: 9999px;
+    background: rgba(5, 11, 19, 0.72);
+    color: #9fb8cf;
+    font-size: 0.58rem;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    max-width: 42%;
+    overflow: hidden;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    transform: translateY(-50%);
+    white-space: nowrap;
+}
+
 #playerInventory .items .lock-indicator {
     position: absolute;
     top: 0.2rem;
@@ -303,10 +324,79 @@ color: black;
 }
 
 #playerEquipment {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin: 0.55rem 0.5rem 0;
+}
+
+.equipment-slot-card {
     display: flex;
-    gap: 0.5rem;
-    flex-flow: row wrap;
-    margin-left: 0.5rem;
+    min-width: 0;
+    min-height: 6.3rem;
+    padding: 0.55rem 0.4rem 0.45rem;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 0.55rem;
+    background: linear-gradient(180deg, rgba(35, 45, 62, 0.92), rgba(8, 12, 20, 0.96));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0.35rem 0.8rem rgba(0, 0, 0, 0.25);
+    align-items: center;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.equipment-slot-card--filled {
+    border-color: rgba(105, 188, 224, 0.42);
+}
+
+.equipment-slot-card__label {
+    display: flex;
+    width: 100%;
+    min-height: 1.3rem;
+    color: #9fb8cf;
+    font-size: 0.56rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    line-height: 1.15;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    text-transform: uppercase;
+    white-space: normal;
+}
+
+.equipment-slot-card__item {
+    position: relative;
+    display: flex;
+    width: 100%;
+    min-height: 4rem;
+    align-items: center;
+    justify-content: center;
+}
+
+.equipment-slot-card__item button {
+    width: 3.55rem;
+    height: 3.55rem;
+    margin: 0;
+    padding: 0;
+    border-radius: 0.55rem;
+    background: rgba(3, 7, 13, 0.86);
+}
+
+.equipment-slot-card__item button i {
+    margin: 0;
+    font-size: 1.55rem;
+}
+
+.equipment-slot-card__item--empty {
+    gap: 0.35rem;
+    color: rgba(190, 206, 220, 0.45);
+    flex-direction: column;
+    font-size: 0.68rem;
+}
+
+.equipment-slot-card__item--empty i {
+    margin: 0;
+    font-size: 1.35rem;
 }
 
 .companion-charm-slot-group {
@@ -369,7 +459,7 @@ color: black;
 }
 
 #playerEquipment i {
-    margin: 0 0.4rem;
+    margin: 0;
 }
 
 #playerEquipment .items {

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -579,7 +579,7 @@ const dungeonEvent = () => {
         if (dungeon.story.monarchUnlocked && dungeon.specialEvents.monarchIgnoredFloor !== dungeon.progress.floor) {
             eventTypes.push("monarch", "monarch");
         }
-        if ( dungeon.progress.floor < 5 && dungeon.progress.room === 1 && player.equipped.length === 6 && player.lvl > 2 && player.lvl > dungeon.progress.floor && !dungeon.roomEvents.stairsIgnored) {
+        if ( dungeon.progress.floor < 5 && dungeon.progress.room === 1 && hasCompleteEquipmentLoadout() && player.lvl > 2 && player.lvl > dungeon.progress.floor && !dungeon.roomEvents.stairsIgnored) {
         	eventTypes.push("stairs");
         	eventTypes.push("stairs");
         }

--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -2122,7 +2122,3 @@ const createEquipmentPrint = (condition, options = {}) => {
         serialized: serializedItem
     };
 }
-
-if (typeof player !== 'undefined' && player) {
-    normalizePlayerEquipmentSlots();
-}

--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -435,7 +435,7 @@ const EQUIPMENT_REROLL_STAT_POOLS = {
     evasive: ["dodge", "dodge", "luck", "luck", "atkSpd", "critRate"],
     boots: ["dodge", "fasterRun", "hp", "def", "hp", "def"],
     damageDefense: ["hp", "def", "atk", "atk", "critRate", "critDmg", "luck"],
-    utility: ["atk", "hp", "def", "atkSpd", "critRate", "critDmg", "vamp", "dodge", "luck", "fasterRun"],
+    utility: ["atk", "hp", "def", "atkSpd", "critRate", "critDmg", "vamp", "dodge", "luck"],
 };
 
 const getEquipmentRerollStatPool = (equipment) => {

--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -10,6 +10,68 @@ const REFINE_STAT_BONUS_PER_LEVEL = 0.08;
 const REFINE_STONE_COMBAT_DROP_CHANCE = 0.16;
 const REFINE_STONE_CHEST_DROP_CHANCE = 0.35;
 
+const EQUIPMENT_SLOT_VERSION = 1;
+const EQUIPMENT_SLOT_DEFINITIONS = Object.freeze([
+    { key: 'weapon', label: 'Weapon', icon: '<i class="ra ra-crossed-swords"></i>' },
+    { key: 'offHand', label: 'Off Hand', icon: '<i class="ra ra-shield"></i>' },
+    { key: 'head', label: 'Head', icon: '<i class="ra ra-knight-helmet"></i>' },
+    { key: 'body', label: 'Body', icon: '<i class="ra ra-vest"></i>' },
+    { key: 'feet', label: 'Feet', icon: '<i class="ra ra-boot-stomp"></i>' },
+    { key: 'accessory', label: 'Accessory', icon: '<i class="fas fa-ring"></i>' },
+]);
+const EQUIPMENT_SLOT_KEYS = EQUIPMENT_SLOT_DEFINITIONS.map((slot) => slot.key);
+
+const getEquipmentSlot = (equipment) => {
+    if (!equipment) {
+        return null;
+    }
+    if (equipment.slot === COMPANION_CHARM_SLOT_KEY
+        || (equipment.category === 'Charm' && equipment.attribute === 'Companion')) {
+        return COMPANION_CHARM_SLOT_KEY;
+    }
+    if (EQUIPMENT_SLOT_KEYS.includes(equipment.slot)) {
+        return equipment.slot;
+    }
+
+    const category = equipment.baseCategory || equipment.category;
+    const type = equipment.type;
+    if (type === 'Weapon' || ['Sword', 'Axe', 'Hammer', 'Dagger', 'Flail', 'Scythe'].includes(category)) {
+        return 'weapon';
+    }
+    if (type === 'Shield' || ['Tower', 'Kite', 'Buckler'].includes(category)) {
+        return 'offHand';
+    }
+    if (type === 'Helmet' || type === 'Mask' || ['Great Helm', 'Horned Helm', 'Mask'].includes(category)) {
+        return 'head';
+    }
+    if (type === 'Armor' || ['Plate', 'Chain', 'Leather'].includes(category)) {
+        return 'body';
+    }
+    if (type === 'Boots' || category === 'Boots') {
+        return 'feet';
+    }
+    if (type === 'Accessory' || ['Ring', 'Amulet', 'Talisman'].includes(category)) {
+        return 'accessory';
+    }
+    return null;
+};
+
+const getEquipmentSlotDefinition = (slotKey) => EQUIPMENT_SLOT_DEFINITIONS.find((slot) => slot.key === slotKey) || null;
+
+const getEquippedItemForSlot = (slotKey) => {
+    if (!player || !Array.isArray(player.equipped)) {
+        return null;
+    }
+    return player.equipped.find((item) => item && getEquipmentSlot(item) === slotKey) || null;
+};
+
+const hasEmptyEquipmentSlotFor = (equipment) => {
+    const slotKey = getEquipmentSlot(equipment);
+    return Boolean(slotKey && slotKey !== COMPANION_CHARM_SLOT_KEY && !getEquippedItemForSlot(slotKey));
+};
+
+const hasCompleteEquipmentLoadout = () => EQUIPMENT_SLOT_KEYS.every((slotKey) => Boolean(getEquippedItemForSlot(slotKey)));
+
 const ensureRefineInventory = () => {
     if (!player) {
         return 0;
@@ -226,7 +288,7 @@ const rerollCompanionCharmStats = (equipment, enemyScaling) => {
 };
 
 const createEquipment = (addToInventory = true, options = {}) => {
-    const { allowCompanionCharm = true, minRarity = null } = options;
+    const { allowCompanionCharm = true, minRarity = null, forcedSlot = null } = options;
     const equipment = {
         category: null,
         attribute: null,
@@ -248,29 +310,49 @@ const createEquipment = (addToInventory = true, options = {}) => {
         equipment.category = 'Charm';
         equipment.slot = COMPANION_CHARM_SLOT_KEY;
     } else {
-        const equipmentAttributes = ["Damage", "Defense"];
-        equipment.attribute = equipmentAttributes[Math.floor(Math.random() * equipmentAttributes.length)];
-        if (equipment.attribute == "Damage") {
+        const emptySlots = player && Array.isArray(player.equipped)
+            ? EQUIPMENT_SLOT_KEYS.filter((slotKey) => !getEquippedItemForSlot(slotKey))
+            : [];
+        const preferEmptySlot = emptySlots.length > 0 && Math.random() < 0.7;
+        const slotPool = preferEmptySlot ? emptySlots : EQUIPMENT_SLOT_KEYS;
+        const selectedSlot = EQUIPMENT_SLOT_KEYS.includes(forcedSlot)
+            ? forcedSlot
+            : slotPool[Math.floor(Math.random() * slotPool.length)];
+        equipment.slot = selectedSlot;
+
+        if (selectedSlot === 'weapon') {
+            equipment.attribute = 'Damage';
             const equipmentCategories = ["Sword", "Axe", "Hammer", "Dagger", "Flail", "Scythe"];
             equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
             equipment.type = "Weapon";
-        } else if (equipment.attribute == "Defense") {
-            const equipmentTypes = ["Armor", "Shield", "Helmet", "Mask", "Boots"];
-            equipment.type = equipmentTypes[Math.floor(Math.random() * equipmentTypes.length)];
-            if (equipment.type == "Armor") {
-                const equipmentCategories = ["Plate", "Chain", "Leather"];
-                equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
-            } else if (equipment.type == "Shield") {
-                const equipmentCategories = ["Tower", "Kite", "Buckler"];
-                equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
-            } else if (equipment.type == "Helmet") {
+        } else if (selectedSlot === 'offHand') {
+            equipment.attribute = 'Defense';
+            equipment.type = 'Shield';
+            const equipmentCategories = ["Tower", "Kite", "Buckler"];
+            equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
+        } else if (selectedSlot === 'head') {
+            equipment.attribute = 'Defense';
+            equipment.type = Math.random() < 0.75 ? 'Helmet' : 'Mask';
+            if (equipment.type === 'Helmet') {
                 const equipmentCategories = ["Great Helm", "Horned Helm"];
                 equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
-            } else if (equipment.type == "Mask") {
+            } else {
                 equipment.category = "Mask";
-            } else if (equipment.type == "Boots") {
-                equipment.category = "Boots";
             }
+        } else if (selectedSlot === 'body') {
+            equipment.attribute = 'Defense';
+            equipment.type = 'Armor';
+            const equipmentCategories = ["Plate", "Chain", "Leather"];
+            equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
+        } else if (selectedSlot === 'feet') {
+            equipment.attribute = 'Defense';
+            equipment.type = 'Boots';
+            equipment.category = 'Boots';
+        } else if (selectedSlot === 'accessory') {
+            equipment.attribute = 'Utility';
+            equipment.type = 'Accessory';
+            const equipmentCategories = ['Ring', 'Amulet', 'Talisman'];
+            equipment.category = equipmentCategories[Math.floor(Math.random() * equipmentCategories.length)];
         }
     }
     const rarityChances = {
@@ -329,7 +411,11 @@ const receiveEquipment = (equipment) => {
         }
         return;
     }
-    if (player.equipped.length < 6) {
+    const slotKey = getEquipmentSlot(equipment);
+    if (slotKey) {
+        equipment.slot = slotKey;
+    }
+    if (hasEmptyEquipmentSlotFor(equipment)) {
         player.equipped.push(equipment);
     } else {
         player.inventory.equipment.push(JSON.stringify(equipment));
@@ -349,6 +435,7 @@ const EQUIPMENT_REROLL_STAT_POOLS = {
     evasive: ["dodge", "dodge", "luck", "luck", "atkSpd", "critRate"],
     boots: ["dodge", "fasterRun", "hp", "def", "hp", "def"],
     damageDefense: ["hp", "def", "atk", "atk", "critRate", "critDmg", "luck"],
+    utility: ["atk", "hp", "def", "atkSpd", "critRate", "critDmg", "vamp", "dodge", "luck", "fasterRun"],
 };
 
 const getEquipmentRerollStatPool = (equipment) => {
@@ -378,6 +465,9 @@ const getEquipmentRerollStatPool = (equipment) => {
             return EQUIPMENT_REROLL_STAT_POOLS.boots;
         }
         return EQUIPMENT_REROLL_STAT_POOLS.defense;
+    }
+    if (equipment.attribute == "Utility" || equipment.type === "Accessory") {
+        return EQUIPMENT_REROLL_STAT_POOLS.utility;
     }
     return [];
 };
@@ -632,6 +722,12 @@ const equipmentIcon = (equipment) => {
         return '<i class="ra ra-arcane-mask"></i>';
     } else if (equipment == "Boots") {
         return '<i class="ra ra-boot-stomp"></i>';
+    } else if (equipment == "Ring") {
+        return '<i class="fas fa-ring"></i>';
+    } else if (equipment == "Amulet") {
+        return '<i class="ra ra-gem-pendant"></i>';
+    } else if (equipment == "Talisman") {
+        return '<i class="ra ra-crystal-ball"></i>';
     } else if (equipment == "Charm") {
         return '<i class="fas fa-gem"></i>';
     }
@@ -664,8 +760,9 @@ const showItemInfo = (item, icon, action, i) => {
     const lockButtonMarkup = `<button id="toggle-lock">${lockButtonLabel}</button>`;
     itemInfo.style.display = "flex";
     dimContainer.style.filter = "brightness(50%)";
+    const itemSlot = getEquipmentSlot(item);
     const equippedItems = action === 'equip'
-        ? (Array.isArray(player.equipped) ? player.equipped.filter(Boolean) : [])
+        ? [getEquippedItemForSlot(itemSlot)].filter(Boolean)
         : (action === 'equip-companion' && getEquippedCompanionCharm() ? [getEquippedCompanionCharm()] : []);
     let comparisonIndex = 0;
     if (isEquipAction && equippedItems.length > 0) {
@@ -757,7 +854,7 @@ const showItemInfo = (item, icon, action, i) => {
                         ? 'Currently Equipped Charm'
                         : translateEquipText('currently-equipped', 'Currently Equipped');
                     const label = equippedItems.length > 1 ? `${baseLabel} (${comparisonIndex + 1}/${equippedItems.length})` : baseLabel;
-                    const navMarkup = hasComparisonItems && !isCompanionAction ? `
+                    const navMarkup = equippedItems.length > 1 && !isCompanionAction ? `
                         <div class="equipment-compare-nav-group">
                             <button type="button" class="equipment-compare-nav equipment-compare-nav--prev" aria-label="${prevLabel}" title="${prevLabel}"${equippedItems.length <= 1 ? ' disabled' : ''}>&#9664;</button>
                             <button type="button" class="equipment-compare-nav equipment-compare-nav--next" aria-label="${nextLabel}" title="${nextLabel}"${equippedItems.length <= 1 ? ' disabled' : ''}>&#9654;</button>
@@ -803,25 +900,22 @@ const showItemInfo = (item, icon, action, i) => {
     let unEquip = document.querySelector("#un-equip");
     unEquip.onclick = function () {
         if (action === "equip") {
-            if (player.equipped.length >= 6) {
-                const comparisonItem = equippedItems.length ? equippedItems[comparisonIndex] || equippedItems[0] : null;
-                const comparisonIndexInEquipped = comparisonItem ? player.equipped.indexOf(comparisonItem) : -1;
+            const slotKey = itemSlot;
+            if (!slotKey || slotKey === COMPANION_CHARM_SLOT_KEY) {
+                sfxDeny.play();
+                return;
+            }
 
-                if (comparisonIndexInEquipped === -1) {
-                    sfxDeny.play();
-                    return;
-                }
+            const comparisonItem = getEquippedItemForSlot(slotKey);
+            const comparisonIndexInEquipped = comparisonItem ? player.equipped.indexOf(comparisonItem) : -1;
+            sfxEquip.play();
+            player.inventory.equipment.splice(i, 1);
+            item.slot = slotKey;
 
-                sfxEquip.play();
-
-                player.inventory.equipment.splice(i, 1);
+            if (comparisonIndexInEquipped >= 0) {
                 player.inventory.equipment.push(JSON.stringify(comparisonItem));
                 player.equipped[comparisonIndexInEquipped] = item;
             } else {
-                sfxEquip.play();
-
-                // Equip the item
-                player.inventory.equipment.splice(i, 1);
                 player.equipped.push(item);
             }
         } else if (action === "unequip") {
@@ -1030,6 +1124,14 @@ const showInventory = () => {
         itemLabel.className = item.rarity;
         itemLabel.innerHTML = `${icon}${equipmentDisplayLabel(item)}`;
         itemDiv.appendChild(itemLabel);
+        const slotDefinition = getEquipmentSlotDefinition(getEquipmentSlot(item));
+        if (slotDefinition) {
+            const slotBadge = document.createElement('span');
+            slotBadge.className = 'inventory-slot-badge';
+            slotBadge.textContent = translateEquipText(`equipment-slot.${slotDefinition.key}`, slotDefinition.label);
+            slotBadge.title = slotBadge.textContent;
+            itemDiv.appendChild(slotBadge);
+        }
         if (isLocked) {
             const lockLabel = translateEquipText('locked', 'Locked');
             const lockIndicator = document.createElement('span');
@@ -1081,27 +1183,46 @@ const showCompanionCharmSlot = () => {
     charmSlot.appendChild(charmDiv);
 };
 
-// Show equipment
+// Show equipment in fixed category slots
 const showEquipment = () => {
-    // Clear the inventory container
-    let playerEquipmentList = document.getElementById("playerEquipment");
+    const playerEquipmentList = document.getElementById("playerEquipment");
+    if (!playerEquipmentList) {
+        return;
+    }
     playerEquipmentList.innerHTML = "";
     showCompanionCharmSlot();
 
-    // Show a message if a player has no equipment
-    if (player.equipped.length == 0) {
-        playerEquipmentList.innerHTML = t('nothing-equipped');
-    }
+    EQUIPMENT_SLOT_DEFINITIONS.forEach((slotDefinition) => {
+        const item = getEquippedItemForSlot(slotDefinition.key);
+        const slotCard = document.createElement('div');
+        slotCard.className = item ? 'equipment-slot-card equipment-slot-card--filled' : 'equipment-slot-card equipment-slot-card--empty';
+        slotCard.dataset.slot = slotDefinition.key;
 
-    for (let i = 0; i < player.equipped.length; i++) {
-        const item = player.equipped[i];
+        const label = translateEquipText(`equipment-slot.${slotDefinition.key}`, slotDefinition.label);
+        const labelElement = document.createElement('span');
+        labelElement.className = 'equipment-slot-card__label';
+        labelElement.textContent = label;
+        slotCard.appendChild(labelElement);
 
-        // Create an element to display the item's name
-        const equipDiv = document.createElement('div');
+        if (!item) {
+            const emptySlot = document.createElement('div');
+            emptySlot.className = 'equipment-slot-card__item equipment-slot-card__item--empty';
+            emptySlot.innerHTML = `${slotDefinition.icon}<span>${translateEquipText('empty-slot', 'Empty')}</span>`;
+            emptySlot.setAttribute('aria-label', `${label}: ${translateEquipText('empty-slot', 'Empty')}`);
+            slotCard.appendChild(emptySlot);
+            playerEquipmentList.appendChild(slotCard);
+            return;
+        }
+
         const icon = equipmentIcon(item.baseCategory || item.category);
         const isLocked = Boolean(item.locked);
-        equipDiv.className = isLocked ? "items locked-item" : "items";
-        equipDiv.innerHTML = `<button class="${item.rarity}">${icon}</button>`;
+        const itemDiv = document.createElement('div');
+        itemDiv.className = isLocked ? 'items locked-item equipment-slot-card__item' : 'items equipment-slot-card__item';
+        const itemButton = document.createElement('button');
+        itemButton.className = item.rarity;
+        itemButton.title = equipmentDisplayLabel(item);
+        itemButton.innerHTML = icon;
+        itemDiv.appendChild(itemButton);
         if (isLocked) {
             const lockLabel = translateEquipText('locked', 'Locked');
             const lockIndicator = document.createElement('span');
@@ -1109,17 +1230,18 @@ const showEquipment = () => {
             lockIndicator.innerHTML = '<i class="fas fa-lock"></i>';
             lockIndicator.setAttribute('aria-hidden', 'true');
             lockIndicator.setAttribute('title', lockLabel);
-            equipDiv.setAttribute('title', lockLabel);
-            equipDiv.appendChild(lockIndicator);
+            itemDiv.appendChild(lockIndicator);
         }
-        equipDiv.addEventListener('click', function () {
-            showItemInfo(item, icon, 'unequip', i);
+        itemDiv.addEventListener('click', function () {
+            const currentIndex = player.equipped.indexOf(item);
+            if (currentIndex >= 0) {
+                showItemInfo(item, icon, 'unequip', currentIndex);
+            }
         });
-
-        // Add the equipDiv to the inventory container
-        playerEquipmentList.appendChild(equipDiv);
-    }
-}
+        slotCard.appendChild(itemDiv);
+        playerEquipmentList.appendChild(slotCard);
+    });
+};
 
 // Apply the equipment stats to the player
 const applyEquipmentStats = () => {
@@ -1228,6 +1350,97 @@ const getEquipmentEffectiveValue = (item) => {
     return Math.max(0, Math.round(value * getEquipmentRefineStatMultiplier(item)));
 };
 
+const normalizePlayerEquipmentSlots = () => {
+    if (!player) {
+        return { movedToInventory: 0, changed: false };
+    }
+    if (!Array.isArray(player.equipped)) {
+        player.equipped = [];
+    }
+    if (!player.inventory || !Array.isArray(player.inventory.equipment)) {
+        ensureRefineInventory();
+    }
+
+    let changed = player.equipmentSlotVersion !== EQUIPMENT_SLOT_VERSION;
+    let movedToInventory = 0;
+    const equippedBySlot = new Map();
+    const movedItems = [];
+
+    const shouldReplaceEquipped = (current, candidate) => {
+        if (Boolean(current.locked) !== Boolean(candidate.locked)) {
+            return Boolean(candidate.locked);
+        }
+        return getEquipmentEffectiveValue(candidate) > getEquipmentEffectiveValue(current);
+    };
+
+    player.equipped.filter(Boolean).forEach((item) => {
+        const slotKey = getEquipmentSlot(item);
+        if (slotKey === COMPANION_CHARM_SLOT_KEY) {
+            if (!player.companionCharm) {
+                player.companionCharm = item;
+            } else {
+                movedItems.push(item);
+                movedToInventory++;
+            }
+            changed = true;
+            return;
+        }
+        if (!slotKey) {
+            movedItems.push(item);
+            movedToInventory++;
+            changed = true;
+            return;
+        }
+        if (item.slot !== slotKey) {
+            item.slot = slotKey;
+            changed = true;
+        }
+        const current = equippedBySlot.get(slotKey);
+        if (!current) {
+            equippedBySlot.set(slotKey, item);
+            return;
+        }
+        if (shouldReplaceEquipped(current, item)) {
+            equippedBySlot.set(slotKey, item);
+            movedItems.push(current);
+        } else {
+            movedItems.push(item);
+        }
+        movedToInventory++;
+        changed = true;
+    });
+
+    const normalizedEquipped = EQUIPMENT_SLOT_KEYS
+        .map((slotKey) => equippedBySlot.get(slotKey))
+        .filter(Boolean);
+    if (normalizedEquipped.length !== player.equipped.length
+        || normalizedEquipped.some((item, index) => item !== player.equipped[index])) {
+        changed = true;
+    }
+    player.equipped = normalizedEquipped;
+
+    const normalizedInventory = player.inventory.equipment.map((serializedItem) => {
+        try {
+            const item = typeof serializedItem === 'string' ? JSON.parse(serializedItem) : serializedItem;
+            const slotKey = getEquipmentSlot(item);
+            if (slotKey && item.slot !== slotKey) {
+                item.slot = slotKey;
+                changed = true;
+            }
+            return JSON.stringify(item);
+        } catch (error) {
+            return serializedItem;
+        }
+    });
+    player.inventory.equipment = normalizedInventory.concat(movedItems.map((item) => JSON.stringify(item)));
+    player.equipmentSlotVersion = EQUIPMENT_SLOT_VERSION;
+
+    if (changed && typeof saveData === 'function') {
+        saveData();
+    }
+    return { movedToInventory, changed };
+};
+
 const legacyEquipmentStatLabel = (stat) => {
     if (stat === 'fasterRun') {
         return 'Faster Run';
@@ -1324,29 +1537,11 @@ const renderEquipmentCard = ({ item, icon, totals, comparisonTotals = null, labe
 };
 
 const findComparableEquippedItem = (item) => {
-    if (!Array.isArray(player.equipped) || player.equipped.length === 0) {
+    const slotKey = getEquipmentSlot(item);
+    if (!slotKey || slotKey === COMPANION_CHARM_SLOT_KEY) {
         return null;
     }
-    const category = item.baseCategory || item.category;
-    const type = item.type || null;
-    const attribute = item.attribute || null;
-    const categoryMatch = player.equipped.find(eq => (eq.baseCategory || eq.category) === category);
-    if (categoryMatch) {
-        return categoryMatch;
-    }
-    if (type) {
-        const typeMatch = player.equipped.find(eq => eq.type === type);
-        if (typeMatch) {
-            return typeMatch;
-        }
-    }
-    if (attribute) {
-        const attributeMatch = player.equipped.find(eq => eq.attribute === attribute);
-        if (attributeMatch) {
-            return attributeMatch;
-        }
-    }
-    return player.equipped[0];
+    return getEquippedItemForSlot(slotKey);
 };
 
 const ensureEquipBestPriorities = () => {
@@ -1630,19 +1825,39 @@ const equipBest = () => {
         return;
     }
     if (typeof sfxEquip !== 'undefined') sfxEquip.play();
-    const maxEquippedSlots = 6;
-    const lockedItems = equippedItems.filter(item => item && item.locked);
-    const unlockedEquipped = equippedItems.filter(item => item && !item.locked);
-    const candidateItems = [...unlockedEquipped];
-    for (const eq of inventoryEquipment) {
-        candidateItems.push(eq);
-    }
-    sortEquipBestCandidates(candidateItems);
-    const lockedSlots = Math.min(lockedItems.length, maxEquippedSlots);
-    const availableSlots = Math.max(0, maxEquippedSlots - lockedSlots);
-    const selected = candidateItems.slice(0, availableSlots);
-    const remaining = candidateItems.slice(availableSlots);
-    const overflowLocked = lockedItems.slice(maxEquippedSlots);
+    const allEquipment = equippedItems.concat(inventoryEquipment);
+    const selected = [];
+    const remaining = [];
+
+    EQUIPMENT_SLOT_KEYS.forEach((slotKey) => {
+        const slotCandidates = allEquipment.filter((item) => getEquipmentSlot(item) === slotKey);
+        if (slotCandidates.length === 0) {
+            return;
+        }
+        const lockedEquipped = equippedItems.find((item) => item.locked && getEquipmentSlot(item) === slotKey);
+        if (lockedEquipped) {
+            lockedEquipped.slot = slotKey;
+            selected.push(lockedEquipped);
+            slotCandidates.forEach((item) => {
+                if (item !== lockedEquipped) {
+                    remaining.push(item);
+                }
+            });
+            return;
+        }
+        sortEquipBestCandidates(slotCandidates);
+        const bestItem = slotCandidates[0];
+        bestItem.slot = slotKey;
+        selected.push(bestItem);
+        remaining.push(...slotCandidates.slice(1));
+    });
+
+    allEquipment.forEach((item) => {
+        if (!getEquipmentSlot(item) && !remaining.includes(item)) {
+            remaining.push(item);
+        }
+    });
+
     let selectedCompanionCharm = equippedCompanionCharm && equippedCompanionCharm.locked
         ? equippedCompanionCharm
         : null;
@@ -1655,10 +1870,9 @@ const equipBest = () => {
         selectedCompanionCharm = companionCharmCandidates[0] || null;
         remainingCompanionCharms = companionCharmCandidates.slice(1);
     }
-    player.equipped = lockedItems.slice(0, maxEquippedSlots).concat(selected).filter(Boolean);
+    player.equipped = selected;
     player.companionCharm = selectedCompanionCharm;
     player.inventory.equipment = remaining
-        .concat(overflowLocked)
         .concat(remainingCompanionCharms)
         .filter(Boolean)
         .map(item => JSON.stringify(item));
@@ -1834,7 +2048,7 @@ const createEquipmentPrint = (condition, options = {}) => {
     const { messageKey = null, ...equipmentOptions } = options;
     let item = createEquipment(false, equipmentOptions);
     const willAutoEquipCompanionCharm = isCompanionCharm(item) && !player.companionCharm;
-    const willAutoEquip = !isCompanionCharm(item) && Array.isArray(player.equipped) ? player.equipped.length < 6 : false;
+    const willAutoEquip = !isCompanionCharm(item) && hasEmptyEquipmentSlotFor(item);
     const placementIndex = willAutoEquipCompanionCharm
         ? -1
         : (willAutoEquip
@@ -1907,4 +2121,8 @@ const createEquipmentPrint = (condition, options = {}) => {
         index: placementIndex,
         serialized: serializedItem
     };
+}
+
+if (typeof player !== 'undefined' && player) {
+    normalizePlayerEquipmentSlots();
 }

--- a/assets/js/forge.js
+++ b/assets/js/forge.js
@@ -35,6 +35,9 @@ const FORGE_CATEGORY_CONFIG = Object.freeze([
     { category: 'Horned Helm', attribute: 'Defense', type: 'Helmet' },
     { category: 'Mask', attribute: 'Defense', type: 'Mask' },
     { category: 'Boots', attribute: 'Defense', type: 'Boots' },
+    { category: 'Ring', attribute: 'Utility', type: 'Accessory' },
+    { category: 'Amulet', attribute: 'Utility', type: 'Accessory' },
+    { category: 'Talisman', attribute: 'Utility', type: 'Accessory' },
 ]);
 
 const closeForgeUnlockModal = () => {
@@ -1091,7 +1094,7 @@ const createForgedEquipment = (item1, item2, item3, targetCategory) => {
     forgedEquipment.category = targetConfig.category;
     forgedEquipment.attribute = targetConfig.attribute;
     forgedEquipment.type = targetConfig.type;
-    forgedEquipment.slot = null;
+    forgedEquipment.slot = typeof getEquipmentSlot === 'function' ? getEquipmentSlot(forgedEquipment) : null;
 
     // Set tier to the same as input items
     forgedEquipment.tier = item1.tier;

--- a/assets/js/forge.js
+++ b/assets/js/forge.js
@@ -1094,7 +1094,8 @@ const createForgedEquipment = (item1, item2, item3, targetCategory) => {
     forgedEquipment.category = targetConfig.category;
     forgedEquipment.attribute = targetConfig.attribute;
     forgedEquipment.type = targetConfig.type;
-    forgedEquipment.slot = typeof getEquipmentSlot === 'function' ? getEquipmentSlot(forgedEquipment) : null;
+    forgedEquipment.slot = null;
+    forgedEquipment.slot = getEquipmentSlot(forgedEquipment);
 
     // Set tier to the same as input items
     forgedEquipment.tier = item1.tier;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,10 @@
 // Use DOMContentLoaded so interactions are available as soon as the DOM is ready
 // rather than waiting for all assets to finish loading
 window.addEventListener("DOMContentLoaded", async function () {
+    if (player && typeof normalizePlayerEquipmentSlots === 'function') {
+        normalizePlayerEquipmentSlots();
+    }
+
     // Apply saved font size on page load
     const advancedStatsDetails = document.querySelector('#advanced-stats');
     const bonusStatsBox = document.querySelector('#bonus-stats');

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -155,6 +155,7 @@ window.addEventListener("DOMContentLoaded", async function () {
                         refineStones: 0
                     },
                     equipped: [],
+                    equipmentSlotVersion: EQUIPMENT_SLOT_VERSION,
                     companionCharm: null,
                     gold: 0,
                     playtime: 0,

--- a/assets/locales/ar.json
+++ b/assets/locales/ar.json
@@ -125,6 +125,15 @@
   "rarity": "الندرة",
   "tier": "الرتبة",
   "equipment": "المعدات",
+  "equipment-slot": {
+    "weapon": "سلاح",
+    "offHand": "اليد الثانوية",
+    "head": "الرأس",
+    "body": "الجسم",
+    "feet": "القدمان",
+    "accessory": "إكسسوار"
+  },
+  "empty-slot": "فارغ",
   "menu": "القائمة",
   "statistics": "الإحصاءات",
   "more": "المزيد",
@@ -454,6 +463,9 @@
     "horned-helm": "خوذة بقرون",
     "mask": "قناع",
     "boots": "حذاء",
+    "ring": "خاتم",
+    "amulet": "تميمة",
+    "talisman": "تعويذة",
     "charm": "تعويذة"
   },
   "enemy-names": {

--- a/assets/locales/de.json
+++ b/assets/locales/de.json
@@ -125,6 +125,15 @@
   "rarity": "Seltenheit",
   "tier": "Tier",
   "equipment": "Ausrüstung",
+  "equipment-slot": {
+    "weapon": "Waffe",
+    "offHand": "Nebenhand",
+    "head": "Kopf",
+    "body": "Körper",
+    "feet": "Füße",
+    "accessory": "Zubehör"
+  },
+  "empty-slot": "Leer",
   "menu": "Menü",
   "statistics": "Statistiken",
   "more": "Mehr",
@@ -454,6 +463,9 @@
     "horned-helm": "Hornhelm",
     "mask": "Maske",
     "boots": "Stiefel",
+    "ring": "Ring",
+    "amulet": "Amulett",
+    "talisman": "Talisman",
     "charm": "Talisman"
   },
   "enemy-names": {
@@ -525,7 +537,10 @@
     "great-helm": "m",
     "horned-helm": "m",
     "mask": "f",
-    "boots": "m"
+    "boots": "m",
+    "ring": "m",
+    "amulet": "n",
+    "talisman": "m"
   },
   "level-up-option": {
     "hp": {

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -125,6 +125,15 @@
   "rarity": "Rarity",
   "tier": "Tier",
   "equipment": "Equipment",
+  "equipment-slot": {
+    "weapon": "Weapon",
+    "offHand": "Off Hand",
+    "head": "Head",
+    "body": "Body",
+    "feet": "Feet",
+    "accessory": "Accessory"
+  },
+  "empty-slot": "Empty",
   "menu": "Menu",
   "statistics": "Statistics",
   "more": "More",
@@ -454,6 +463,9 @@
     "horned-helm": "Horned Helm",
     "mask": "Mask",
     "boots": "Boots",
+    "ring": "Ring",
+    "amulet": "Amulet",
+    "talisman": "Talisman",
     "charm": "Charm"
   },
   "enemy-names": {

--- a/assets/locales/es.json
+++ b/assets/locales/es.json
@@ -125,6 +125,15 @@
   "rarity": "Rareza",
   "tier": "Grado",
   "equipment": "Equipo",
+  "equipment-slot": {
+    "weapon": "Arma",
+    "offHand": "Mano secundaria",
+    "head": "Cabeza",
+    "body": "Cuerpo",
+    "feet": "Pies",
+    "accessory": "Accesorio"
+  },
+  "empty-slot": "Vacío",
   "menu": "Menú",
   "statistics": "Estadísticas",
   "more": "Más",
@@ -454,6 +463,9 @@
     "horned-helm": "Yelmo con cuernos",
     "mask": "Máscara",
     "boots": "Botas",
+    "ring": "Anillo",
+    "amulet": "Amuleto",
+    "talisman": "Talismán",
     "charm": "Amuleto"
   },
   "enemy-names": {

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -125,6 +125,15 @@
   "rarity": "Rareté",
   "tier": "Palier",
   "equipment": "Équipement",
+  "equipment-slot": {
+    "weapon": "Arme",
+    "offHand": "Main secondaire",
+    "head": "Tête",
+    "body": "Torse",
+    "feet": "Pieds",
+    "accessory": "Accessoire"
+  },
+  "empty-slot": "Vide",
   "menu": "Menu",
   "statistics": "Statistiques",
   "more": "Plus",
@@ -454,6 +463,9 @@
     "horned-helm": "Heaume cornu",
     "mask": "Masque",
     "boots": "Bottes",
+    "ring": "Anneau",
+    "amulet": "Amulette",
+    "talisman": "Talisman",
     "charm": "Charme"
   },
   "enemy-names": {

--- a/assets/locales/hi.json
+++ b/assets/locales/hi.json
@@ -125,6 +125,15 @@
   "rarity": "दुर्लभता",
   "tier": "टियर",
   "equipment": "उपकरण",
+  "equipment-slot": {
+    "weapon": "हथियार",
+    "offHand": "सहायक हाथ",
+    "head": "सिर",
+    "body": "शरीर",
+    "feet": "पैर",
+    "accessory": "सहायक वस्तु"
+  },
+  "empty-slot": "खाली",
   "menu": "मेनू",
   "statistics": "सांख्यिकी",
   "more": "और",
@@ -454,6 +463,9 @@
     "horned-helm": "सींगदार हेल्म",
     "mask": "मुखौटा",
     "boots": "बूट",
+    "ring": "अंगूठी",
+    "amulet": "ताबीज",
+    "talisman": "तावीज़",
     "charm": "चार्म"
   },
   "enemy-names": {

--- a/assets/locales/id.json
+++ b/assets/locales/id.json
@@ -125,6 +125,15 @@
   "rarity": "Kelangkaan",
   "tier": "Tier",
   "equipment": "Perlengkapan",
+  "equipment-slot": {
+    "weapon": "Senjata",
+    "offHand": "Tangan Kedua",
+    "head": "Kepala",
+    "body": "Tubuh",
+    "feet": "Kaki",
+    "accessory": "Aksesori"
+  },
+  "empty-slot": "Kosong",
   "menu": "Menu",
   "statistics": "Statistik",
   "more": "Lainnya",
@@ -454,6 +463,9 @@
     "horned-helm": "Helm Bertanduk",
     "mask": "Topeng",
     "boots": "Sepatu",
+    "ring": "Cincin",
+    "amulet": "Amulet",
+    "talisman": "Jimat",
     "charm": "Jimat"
   },
   "enemy-names": {

--- a/assets/locales/it.json
+++ b/assets/locales/it.json
@@ -125,6 +125,15 @@
   "rarity": "Rarità",
   "tier": "Grado",
   "equipment": "Equipaggiamento",
+  "equipment-slot": {
+    "weapon": "Arma",
+    "offHand": "Mano secondaria",
+    "head": "Testa",
+    "body": "Corpo",
+    "feet": "Piedi",
+    "accessory": "Accessorio"
+  },
+  "empty-slot": "Vuoto",
   "menu": "Menu",
   "statistics": "Statistiche",
   "more": "Altro",
@@ -454,6 +463,9 @@
     "horned-helm": "Elmo cornuto",
     "mask": "Maschera",
     "boots": "Stivali",
+    "ring": "Anello",
+    "amulet": "Amuleto",
+    "talisman": "Talismano",
     "charm": "Amuleto"
   },
   "enemy-names": {

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -125,6 +125,15 @@
   "rarity": "レア度",
   "tier": "ティア",
   "equipment": "装備",
+  "equipment-slot": {
+    "weapon": "武器",
+    "offHand": "オフハンド",
+    "head": "頭",
+    "body": "胴",
+    "feet": "足",
+    "accessory": "アクセサリー"
+  },
+  "empty-slot": "空き",
   "menu": "メニュー",
   "statistics": "統計",
   "more": "もっと見る",
@@ -454,6 +463,9 @@
     "horned-helm": "ホーンヘルム",
     "mask": "マスク",
     "boots": "ブーツ",
+    "ring": "指輪",
+    "amulet": "アミュレット",
+    "talisman": "タリスマン",
     "charm": "チャーム"
   },
   "enemy-names": {

--- a/assets/locales/ko.json
+++ b/assets/locales/ko.json
@@ -125,6 +125,15 @@
   "rarity": "희귀도",
   "tier": "티어",
   "equipment": "장비",
+  "equipment-slot": {
+    "weapon": "무기",
+    "offHand": "보조 장비",
+    "head": "머리",
+    "body": "몸통",
+    "feet": "발",
+    "accessory": "장신구"
+  },
+  "empty-slot": "비어 있음",
   "menu": "메뉴",
   "statistics": "통계",
   "more": "더보기",
@@ -454,6 +463,9 @@
     "horned-helm": "뿔 투구",
     "mask": "가면",
     "boots": "부츠",
+    "ring": "반지",
+    "amulet": "부적",
+    "talisman": "탈리스만",
     "charm": "부적"
   },
   "enemy-names": {

--- a/assets/locales/pl.json
+++ b/assets/locales/pl.json
@@ -125,6 +125,15 @@
   "rarity": "Rzadkość",
   "tier": "Stopień",
   "equipment": "Ekwipunek",
+  "equipment-slot": {
+    "weapon": "Broń",
+    "offHand": "Druga ręka",
+    "head": "Głowa",
+    "body": "Tułów",
+    "feet": "Stopy",
+    "accessory": "Akcesorium"
+  },
+  "empty-slot": "Pusty",
   "menu": "Menu",
   "statistics": "Statystyki",
   "more": "Więcej",
@@ -454,6 +463,9 @@
     "horned-helm": "Rogaty hełm",
     "mask": "Maska",
     "boots": "Buty",
+    "ring": "Pierścień",
+    "amulet": "Amulet",
+    "talisman": "Talizman",
     "charm": "Amulet"
   },
   "enemy-names": {

--- a/assets/locales/pt.json
+++ b/assets/locales/pt.json
@@ -125,6 +125,15 @@
   "rarity": "Raridade",
   "tier": "Patamar",
   "equipment": "Equipamento",
+  "equipment-slot": {
+    "weapon": "Arma",
+    "offHand": "Mão secundária",
+    "head": "Cabeça",
+    "body": "Corpo",
+    "feet": "Pés",
+    "accessory": "Acessório"
+  },
+  "empty-slot": "Vazio",
   "menu": "Menu",
   "statistics": "Estatísticas",
   "more": "Mais",
@@ -454,6 +463,9 @@
     "horned-helm": "Elmo com chifres",
     "mask": "Máscara",
     "boots": "Botas",
+    "ring": "Anel",
+    "amulet": "Amuleto",
+    "talisman": "Talismã",
     "charm": "Amuleto"
   },
   "equipment-genders": {
@@ -472,7 +484,10 @@
     "great-helm": "m",
     "horned-helm": "m",
     "mask": "f",
-    "boots": "f"
+    "boots": "f",
+    "ring": "m",
+    "amulet": "m",
+    "talisman": "m"
   },
   "enemy-names": {
     "goblin": "Goblin",

--- a/assets/locales/ro.json
+++ b/assets/locales/ro.json
@@ -125,6 +125,15 @@
   "rarity": "Raritate",
   "tier": "Nivel",
   "equipment": "Echipament",
+  "equipment-slot": {
+    "weapon": "Armă",
+    "offHand": "Mâna secundară",
+    "head": "Cap",
+    "body": "Corp",
+    "feet": "Picioare",
+    "accessory": "Accesoriu"
+  },
+  "empty-slot": "Gol",
   "menu": "Meniu",
   "statistics": "Statistici",
   "more": "Mai multe",
@@ -452,6 +461,9 @@
     "horned-helm": "Coif cu coarne",
     "mask": "Mască",
     "boots": "Cizme",
+    "ring": "Inel",
+    "amulet": "Amuletă",
+    "talisman": "Talisman",
     "charm": "Amuletă"
   },
   "enemy-names": {

--- a/assets/locales/ru.json
+++ b/assets/locales/ru.json
@@ -125,6 +125,15 @@
   "rarity": "Редкость",
   "tier": "Тир",
   "equipment": "Экипировка",
+  "equipment-slot": {
+    "weapon": "Оружие",
+    "offHand": "Левая рука",
+    "head": "Голова",
+    "body": "Тело",
+    "feet": "Обувь",
+    "accessory": "Аксессуар"
+  },
+  "empty-slot": "Пусто",
   "menu": "Меню",
   "statistics": "Статистика",
   "more": "Ещё",
@@ -454,6 +463,9 @@
     "horned-helm": "Рогатый шлем",
     "mask": "Маска",
     "boots": "Ботинки",
+    "ring": "Кольцо",
+    "amulet": "Амулет",
+    "talisman": "Талисман",
     "charm": "Амулет"
   },
   "enemy-names": {

--- a/assets/locales/tr.json
+++ b/assets/locales/tr.json
@@ -125,6 +125,15 @@
   "rarity": "Nadirlik",
   "tier": "Kademe",
   "equipment": "Ekipman",
+  "equipment-slot": {
+    "weapon": "Silah",
+    "offHand": "İkinci El",
+    "head": "Baş",
+    "body": "Gövde",
+    "feet": "Ayak",
+    "accessory": "Aksesuar"
+  },
+  "empty-slot": "Boş",
   "menu": "Menü",
   "statistics": "İstatistikler",
   "more": "Daha fazla",
@@ -454,6 +463,9 @@
     "horned-helm": "Boynuzlu Miğfer",
     "mask": "Maske",
     "boots": "Botlar",
+    "ring": "Yüzük",
+    "amulet": "Muska",
+    "talisman": "Tılsım",
     "charm": "Tılsım"
   },
   "enemy-names": {

--- a/assets/locales/uk.json
+++ b/assets/locales/uk.json
@@ -125,6 +125,15 @@
   "rarity": "Рідкісність",
   "tier": "Тир",
   "equipment": "Спорядження",
+  "equipment-slot": {
+    "weapon": "Зброя",
+    "offHand": "Друга рука",
+    "head": "Голова",
+    "body": "Тіло",
+    "feet": "Ноги",
+    "accessory": "Аксесуар"
+  },
+  "empty-slot": "Порожньо",
   "menu": "Меню",
   "statistics": "Статистика",
   "more": "Більше",
@@ -454,6 +463,9 @@
     "horned-helm": "Рогатий шолом",
     "mask": "Маска",
     "boots": "Чоботи",
+    "ring": "Перстень",
+    "amulet": "Амулет",
+    "talisman": "Талісман",
     "charm": "Амулет"
   },
   "enemy-names": {

--- a/assets/locales/zh.json
+++ b/assets/locales/zh.json
@@ -119,6 +119,15 @@
   "rarity": "稀有度",
   "tier": "阶级",
   "equipment": "装备",
+  "equipment-slot": {
+    "weapon": "武器",
+    "offHand": "副手",
+    "head": "头部",
+    "body": "身体",
+    "feet": "脚部",
+    "accessory": "饰品"
+  },
+  "empty-slot": "空",
   "menu": "菜单",
   "statistics": "统计",
   "more": "更多",
@@ -457,6 +466,9 @@
     "horned-helm": "角盔",
     "mask": "面具",
     "boots": "靴子",
+    "ring": "戒指",
+    "amulet": "护身符",
+    "talisman": "符咒",
     "charm": "护符"
   },
   "enemy-names": {

--- a/tests/equipment-slots.test.js
+++ b/tests/equipment-slots.test.js
@@ -82,6 +82,34 @@ test('accessories are obtainable through normal equipment generation', () => {
     assert.ok(generated.stats.length > 0);
 });
 
+test('accessory rerolls never include Faster Run', () => {
+    const context = createContext();
+    context.player = {
+        equipped: [],
+        inventory: { consumables: [], equipment: [], refineStones: 0 },
+        companionCharm: null,
+    };
+    context.dungeon = {
+        progress: { floor: 1 },
+        settings: { enemyLvlGap: 1, enemyBaseLvl: 1, enemyScaling: 1.1 },
+    };
+    context.randomizeNum = (min) => Math.round(min);
+    context.randomizeDecimal = (min) => min;
+    context.clampEquipmentLevel = (level) => level;
+    context.clampEquipmentTier = (tier) => tier;
+    context.getEquipmentTierFromEnemyScaling = () => 1;
+    context.getEnemyScalingFromEquipmentTier = () => 1.1;
+    evaluate(context, 'Math.random = () => 0.999');
+
+    const generated = evaluate(context, `createEquipment(false, {
+        allowCompanionCharm: false,
+        forcedSlot: 'accessory',
+        minRarity: 'Rare'
+    })`);
+    const statKeys = generated.stats.map((stat) => Object.keys(stat)[0]);
+    assert.equal(statKeys.includes('fasterRun'), false);
+});
+
 test('legacy migration is lossless and keeps a locked duplicate equipped', () => {
     const context = createContext();
     const highValueSword = item({ category: 'Sword', type: 'Weapon', attribute: 'Damage', value: 500 });

--- a/tests/equipment-slots.test.js
+++ b/tests/equipment-slots.test.js
@@ -7,6 +7,7 @@ const vm = require('node:vm');
 const root = path.resolve(__dirname, '..');
 const equipmentSource = fs.readFileSync(path.join(root, 'assets/js/equipment.js'), 'utf8');
 const dungeonSource = fs.readFileSync(path.join(root, 'assets/js/dungeon.js'), 'utf8');
+const mainSource = fs.readFileSync(path.join(root, 'assets/js/main.js'), 'utf8');
 
 const createContext = () => {
     const context = vm.createContext({
@@ -154,6 +155,19 @@ test('drop and equip paths use slot availability instead of a generic six-item c
     assert.doesNotMatch(equipmentSource, /const maxEquippedSlots = 6/);
     assert.match(dungeonSource, /hasCompleteEquipmentLoadout\(\)/);
     assert.doesNotMatch(dungeonSource, /player\.equipped\.length === 6/);
+});
+
+test('legacy slot migration runs during application initialization when saveData is available', () => {
+    const migrationCall = 'normalizePlayerEquipmentSlots();';
+    const migrationIndex = mainSource.indexOf(migrationCall);
+    const initialPlayerRoutingIndex = mainSource.indexOf('if (player === null)');
+
+    assert.ok(migrationIndex >= 0, 'main.js is missing the startup equipment migration');
+    assert.ok(migrationIndex < initialPlayerRoutingIndex, 'equipment migration must run before initial player routing');
+    assert.doesNotMatch(
+        equipmentSource,
+        /if \(typeof player !== 'undefined' && player\) \{\s*normalizePlayerEquipmentSlots\(\);/,
+    );
 });
 
 test('every locale includes slot labels and accessory item names', () => {

--- a/tests/equipment-slots.test.js
+++ b/tests/equipment-slots.test.js
@@ -1,0 +1,179 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const equipmentSource = fs.readFileSync(path.join(root, 'assets/js/equipment.js'), 'utf8');
+const dungeonSource = fs.readFileSync(path.join(root, 'assets/js/dungeon.js'), 'utf8');
+
+const createContext = () => {
+    const context = vm.createContext({
+        console,
+        saveCalls: 0,
+        playerLoadStats() {},
+        sfxEquip: { play() {} },
+        sfxDeny: { play() {} },
+    });
+    context.saveData = () => { context.saveCalls += 1; };
+    vm.runInContext(equipmentSource, context);
+    return context;
+};
+
+const evaluate = (context, expression) => vm.runInContext(expression, context);
+const plain = (value) => JSON.parse(JSON.stringify(value));
+
+const item = ({ category, type, attribute, value = 10, locked = false, slot = null }) => ({
+    category,
+    type,
+    attribute,
+    value,
+    locked,
+    slot,
+    rarity: 'Rare',
+    lvl: 10,
+    tier: 1,
+    stats: [{ atk: 5 }],
+});
+
+test('legacy item categories map to the six fixed equipment slots', () => {
+    const context = createContext();
+    const slots = evaluate(context, `([
+        getEquipmentSlot({ category: 'Sword', type: 'Weapon', attribute: 'Damage' }),
+        getEquipmentSlot({ category: 'Buckler', type: 'Shield', attribute: 'Defense' }),
+        getEquipmentSlot({ category: 'Mask', type: 'Mask', attribute: 'Defense' }),
+        getEquipmentSlot({ category: 'Plate', type: 'Armor', attribute: 'Defense' }),
+        getEquipmentSlot({ category: 'Boots', type: 'Boots', attribute: 'Defense' }),
+        getEquipmentSlot({ category: 'Ring', type: 'Accessory', attribute: 'Utility' }),
+    ])`);
+    assert.deepEqual(plain(slots), ['weapon', 'offHand', 'head', 'body', 'feet', 'accessory']);
+    assert.equal(evaluate(context, 'EQUIPMENT_SLOT_DEFINITIONS.length'), 6);
+});
+
+test('accessories are obtainable through normal equipment generation', () => {
+    const context = createContext();
+    context.player = {
+        equipped: [],
+        inventory: { consumables: [], equipment: [], refineStones: 0 },
+        companionCharm: null,
+    };
+    context.dungeon = {
+        progress: { floor: 1 },
+        settings: { enemyLvlGap: 1, enemyBaseLvl: 1, enemyScaling: 1.1 },
+    };
+    context.randomizeNum = (min) => Math.round(min);
+    context.randomizeDecimal = (min) => min;
+    context.clampEquipmentLevel = (level) => level;
+    context.clampEquipmentTier = (tier) => tier;
+    context.getEquipmentTierFromEnemyScaling = () => 1;
+    context.getEnemyScalingFromEquipmentTier = () => 1.1;
+
+    const generated = evaluate(context, `createEquipment(false, {
+        allowCompanionCharm: false,
+        forcedSlot: 'accessory',
+        minRarity: 'Rare'
+    })`);
+    assert.equal(generated.slot, 'accessory');
+    assert.equal(generated.type, 'Accessory');
+    assert.equal(generated.attribute, 'Utility');
+    assert.ok(['Ring', 'Amulet', 'Talisman'].includes(generated.category));
+    assert.ok(generated.stats.length > 0);
+});
+
+test('legacy migration is lossless and keeps a locked duplicate equipped', () => {
+    const context = createContext();
+    const highValueSword = item({ category: 'Sword', type: 'Weapon', attribute: 'Damage', value: 500 });
+    const lockedDagger = item({ category: 'Dagger', type: 'Weapon', attribute: 'Damage', value: 20, locked: true });
+    const armor = item({ category: 'Plate', type: 'Armor', attribute: 'Defense', value: 90 });
+    const boots = item({ category: 'Boots', type: 'Boots', attribute: 'Defense', value: 70 });
+    const shield = item({ category: 'Buckler', type: 'Shield', attribute: 'Defense', value: 80 });
+
+    context.player = {
+        equipped: [highValueSword, lockedDagger, armor, boots],
+        inventory: { consumables: [], equipment: [JSON.stringify(shield)], refineStones: 0 },
+        companionCharm: null,
+    };
+
+    const result = evaluate(context, 'normalizePlayerEquipmentSlots()');
+    assert.deepEqual(plain(result), { movedToInventory: 1, changed: true });
+    assert.equal(context.player.equipmentSlotVersion, 1);
+    assert.equal(context.player.equipped.length, 3);
+    assert.equal(context.player.equipped.find((entry) => entry.slot === 'weapon').category, 'Dagger');
+    assert.equal(context.player.equipped.find((entry) => entry.slot === 'body').category, 'Plate');
+    assert.equal(context.player.equipped.find((entry) => entry.slot === 'feet').category, 'Boots');
+
+    const inventory = context.player.inventory.equipment.map((entry) => JSON.parse(entry));
+    assert.equal(inventory.length, 2);
+    assert.ok(inventory.some((entry) => entry.category === 'Sword'));
+    assert.ok(inventory.some((entry) => entry.category === 'Buckler' && entry.slot === 'offHand'));
+    assert.equal(context.player.equipped.length + inventory.length, 5);
+    assert.equal(context.saveCalls, 1);
+
+    const migratedState = JSON.stringify(context.player);
+    const secondResult = evaluate(context, 'normalizePlayerEquipmentSlots()');
+    assert.deepEqual(plain(secondResult), { movedToInventory: 0, changed: false });
+    assert.equal(JSON.stringify(context.player), migratedState);
+    assert.equal(context.saveCalls, 1);
+});
+
+test('Equip Best chooses one best item per slot and preserves locked equipped items', () => {
+    const context = createContext();
+    const lockedSword = item({ category: 'Sword', type: 'Weapon', attribute: 'Damage', value: 10, locked: true, slot: 'weapon' });
+    const strongerAxe = item({ category: 'Axe', type: 'Weapon', attribute: 'Damage', value: 500, slot: 'weapon' });
+    const weakArmor = item({ category: 'Leather', type: 'Armor', attribute: 'Defense', value: 20, slot: 'body' });
+    const strongArmor = item({ category: 'Plate', type: 'Armor', attribute: 'Defense', value: 200, slot: 'body' });
+    const ring = item({ category: 'Ring', type: 'Accessory', attribute: 'Utility', value: 75, slot: 'accessory' });
+
+    context.player = {
+        equipped: [lockedSword, weakArmor],
+        inventory: {
+            consumables: [],
+            equipment: [strongerAxe, strongArmor, ring].map((entry) => JSON.stringify(entry)),
+            refineStones: 0,
+        },
+        companionCharm: null,
+        preferences: { equipBestUseCustom: false, equipBestPriorities: [] },
+    };
+
+    evaluate(context, 'equipBest()');
+    assert.deepEqual(
+        plain(context.player.equipped.map((entry) => [entry.slot, entry.category])),
+        [['weapon', 'Sword'], ['body', 'Plate'], ['accessory', 'Ring']],
+    );
+    const inventory = context.player.inventory.equipment.map((entry) => JSON.parse(entry));
+    assert.ok(inventory.some((entry) => entry.category === 'Axe'));
+    assert.ok(inventory.some((entry) => entry.category === 'Leather'));
+    assert.equal(context.player.equipped.length + inventory.length, 5);
+});
+
+test('drop and equip paths use slot availability instead of a generic six-item cap', () => {
+    assert.match(equipmentSource, /hasEmptyEquipmentSlotFor\(equipment\)/);
+    assert.match(equipmentSource, /hasEmptyEquipmentSlotFor\(item\)/);
+    assert.doesNotMatch(equipmentSource, /player\.equipped\.length < 6/);
+    assert.doesNotMatch(equipmentSource, /const maxEquippedSlots = 6/);
+    assert.match(dungeonSource, /hasCompleteEquipmentLoadout\(\)/);
+    assert.doesNotMatch(dungeonSource, /player\.equipped\.length === 6/);
+});
+
+test('every locale includes slot labels and accessory item names', () => {
+    const localeDirectory = path.join(root, 'assets/locales');
+    const localeFiles = fs.readdirSync(localeDirectory).filter((file) => file.endsWith('.json'));
+    const slotKeys = ['weapon', 'offHand', 'head', 'body', 'feet', 'accessory'];
+    const accessoryNames = ['ring', 'amulet', 'talisman'];
+
+    for (const file of localeFiles) {
+        const locale = JSON.parse(fs.readFileSync(path.join(localeDirectory, file), 'utf8'));
+        assert.ok(locale['equipment-slot'], `${file} is missing equipment-slot`);
+        assert.ok(locale['empty-slot'], `${file} is missing empty-slot`);
+        for (const slotKey of slotKeys) {
+            assert.ok(locale['equipment-slot'][slotKey], `${file} is missing equipment-slot.${slotKey}`);
+        }
+        for (const itemName of accessoryNames) {
+            assert.ok(locale['equipment-names'][itemName], `${file} is missing equipment-names.${itemName}`);
+            if (locale['equipment-genders']) {
+                assert.ok(locale['equipment-genders'][itemName], `${file} is missing equipment-genders.${itemName}`);
+            }
+        }
+    }
+});

--- a/tests/forge-target-category.test.js
+++ b/tests/forge-target-category.test.js
@@ -6,27 +6,30 @@ const vm = require('node:vm');
 
 const root = path.resolve(__dirname, '..');
 const forgeSource = fs.readFileSync(path.join(root, 'assets/js/forge.js'), 'utf8');
+const equipmentSource = fs.readFileSync(path.join(root, 'assets/js/equipment.js'), 'utf8');
+const equipmentSlotHelpersSource = equipmentSource.split('const ensureRefineInventory')[0];
 const indexSource = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 
 const createForgeContext = () => {
     const context = vm.createContext({
-        createEquipment: () => ({
-            category: 'Sword',
-            attribute: 'Damage',
-            type: 'Weapon',
-            rarity: 'Common',
-            lvl: 1,
-            tier: 1,
-            value: 1,
-            stats: [],
-            slot: null,
-        }),
         clampEquipmentLevel: (level) => Math.min(100, level),
         randomizeNum: (min) => min,
         rerollEquipmentStats: (equipment) => {
             equipment.stats = [{ pool: `${equipment.attribute}:${equipment.type}` }];
             equipment.icon = `icon:${equipment.category}`;
         },
+    });
+    vm.runInContext(equipmentSlotHelpersSource, context);
+    context.createEquipment = () => ({
+        category: 'Sword',
+        attribute: 'Damage',
+        type: 'Weapon',
+        rarity: 'Common',
+        lvl: 1,
+        tier: 1,
+        value: 1,
+        stats: [],
+        slot: 'weapon',
     });
     vm.runInContext(forgeSource, context);
     return context;
@@ -46,6 +49,7 @@ test('forging creates the exact gear piece selected by the player', () => {
     assert.equal(result.category, 'Great Helm');
     assert.equal(result.attribute, 'Defense');
     assert.equal(result.type, 'Helmet');
+    assert.equal(result.slot, 'head');
     assert.equal(result.tier, 4);
     assert.equal(result.rarity, 'Epic');
     assert.deepEqual(JSON.parse(JSON.stringify(result.stats)), [{ pool: 'Defense:Helmet' }]);
@@ -64,6 +68,21 @@ test('every forge target maps to a valid non-charm equipment category', () => {
         assert.ok(config.category);
         assert.ok(['Damage', 'Defense', 'Utility'].includes(config.attribute));
         assert.ok(config.type);
+        const result = vm.runInContext(`
+            createForgedEquipment(
+                { tier: 1, lvl: 1, rarity: 'Common' },
+                { tier: 1, lvl: 1, rarity: 'Common' },
+                { tier: 1, lvl: 1, rarity: 'Common' },
+                ${JSON.stringify(config.category)}
+            )
+        `, context);
+        const expectedSlot = vm.runInContext(`getEquipmentSlot(${JSON.stringify({
+            category: config.category,
+            attribute: config.attribute,
+            type: config.type,
+            slot: null,
+        })})`, context);
+        assert.equal(result.slot, expectedSlot, `${config.category} forged into the wrong slot`);
     }
     assert.deepEqual(
         JSON.parse(JSON.stringify(configs.filter(({ type }) => type === 'Accessory').map(({ category }) => category))),

--- a/tests/forge-target-category.test.js
+++ b/tests/forge-target-category.test.js
@@ -57,14 +57,18 @@ test('every forge target maps to a valid non-charm equipment category', () => {
     const context = createForgeContext();
     const configs = vm.runInContext('FORGE_CATEGORY_CONFIG', context);
 
-    assert.equal(configs.length, 16);
+    assert.equal(configs.length, 19);
     assert.equal(new Set(configs.map(({ category }) => category)).size, configs.length);
     assert.equal(configs.some(({ category }) => category === 'Charm'), false);
     for (const config of configs) {
         assert.ok(config.category);
-        assert.ok(config.attribute === 'Damage' || config.attribute === 'Defense');
+        assert.ok(['Damage', 'Defense', 'Utility'].includes(config.attribute));
         assert.ok(config.type);
     }
+    assert.deepEqual(
+        JSON.parse(JSON.stringify(configs.filter(({ type }) => type === 'Accessory').map(({ category }) => category))),
+        ['Ring', 'Amulet', 'Talisman'],
+    );
 });
 
 test('forging rejects an unknown target category', () => {


### PR DESCRIPTION
## Why

Community feedback repeatedly called out that the current unrestricted six-item pool allows six weapons to be equipped and compares new drops against unrelated gear.

This implements the slotted-equipment proposal shared with the community:

- Wishlist discussion: https://www.reddit.com/r/QuickDungeonCrawler/comments/1twhk26/update_400_wishlist/
- Prototype teaser: https://www.reddit.com/r/QuickDungeonCrawler/comments/1vcuhec/slotted_equipment_teaser/

## Changes

- Add six fixed player equipment slots: Weapon, Off Hand, Head, Body, Feet, and Accessory.
- Keep Companion Charm as a separate companion-only slot.
- Add Ring, Amulet, and Talisman accessory drops and Forge targets.
- Exclude Faster Run from the Accessory stat pool.
- Prefer empty equipment slots while a loadout is incomplete.
- Auto-equip drops only when their matching slot is empty.
- Compare inventory items only with the currently equipped item in the same slot.
- Replace only the matching slot and return the displaced item to inventory.
- Update Equip Best to choose one item per slot while preserving locked equipped items.
- Add a versioned, idempotent save migration that preserves every legacy item and moves duplicate-slot items to inventory without selling them.
- Replace the generic equipment row with a labeled mobile slot grid.
- Add slot and accessory translations for all 17 locales.
- Update Forge and early-progression completeness checks for the new slot model.

## Issue

The previous system treated `player.equipped` as a flat pool capped at six items. This allowed duplicate item types, including six weapons, made comparisons ambiguous, and did not resemble recognizable character equipment.

## Testing

- `node --check` for every tracked and untracked JavaScript file
- `node --test tests/*.test.js` — 95 tests passed
- `git diff --check`
- Dedicated slot tests cover legacy mapping, accessory generation, locked-item migration, item-count preservation, migration idempotence and startup timing, per-slot Equip Best, Forge target-slot inference, removal of the generic cap, complete-loadout detection, and locale coverage.
- Browser migration test confirmed a legacy two-weapon save is immediately persisted as one equipped weapon plus one preserved inventory item.
- Mobile browser smoke test at a 608 px viewport in English and French.
- Verified all six labels, including wrapped long translations such as `Main secondaire`.
- Verified inventory item details show only the same-slot comparison and no unrelated navigation.
- Verified same-slot replacement returns the displaced item to inventory.
- Verified no in-page `error` or `unhandledrejection` events during the interaction.

## Verification

1. Load a legacy save containing several equipped weapons.
2. Confirm one weapon remains equipped and every displaced item is preserved in inventory.
3. Open Inventory and confirm the six labeled player slots plus the separate Companion Charm section.
4. Inspect an inventory item and confirm it compares only against its matching slot.
5. Equip it and confirm only that slot changes.
6. Use Equip Best and confirm each category contains at most one item.
7. Obtain or Forge an Accessory and confirm it uses the Accessory slot.
