### PR TITLE
fix: preserve inventory scroll in item details

### DIFF
--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -1104,6 +1104,9 @@ const updateInventoryItemCount = () => {
 
 const showInventory = () => {
     let playerInventoryList = document.getElementById("playerInventory");
+    const itemInfo = document.getElementById("equipmentInfo");
+    const preserveScrollPosition = itemInfo && itemInfo.style.display === "flex";
+    const previousScrollTop = preserveScrollPosition ? playerInventoryList.scrollTop : 0;
     playerInventoryList.innerHTML = "";
 
     updateInventoryItemCount();
@@ -1149,6 +1152,7 @@ const showInventory = () => {
         // Add the itemDiv to the inventory container
         playerInventoryList.appendChild(itemDiv);
     }
+    playerInventoryList.scrollTop = previousScrollTop;
 }
 
 const showCompanionCharmSlot = () => {

--- a/tests/equipment-slots.test.js
+++ b/tests/equipment-slots.test.js
@@ -52,6 +52,65 @@ test('legacy item categories map to the six fixed equipment slots', () => {
     assert.equal(evaluate(context, 'EQUIPMENT_SLOT_DEFINITIONS.length'), 6);
 });
 
+test('inventory refresh preserves scroll position while equipment info is open', () => {
+    const context = createContext();
+    const inventoryList = {
+        children: [],
+        scrollTop: 120,
+        _innerHTML: '',
+        set innerHTML(value) {
+            this._innerHTML = value;
+            this.children = [];
+            this.scrollTop = 0;
+        },
+        get innerHTML() {
+            return this._innerHTML;
+        },
+        appendChild(child) {
+            this.children.push(child);
+        },
+    };
+    const createElement = () => ({
+        className: '',
+        textContent: '',
+        innerHTML: '',
+        title: '',
+        children: [],
+        appendChild(child) { this.children.push(child); },
+        setAttribute() {},
+        addEventListener() {},
+    });
+    const count = createElement();
+    const limit = createElement();
+    const equipmentInfo = { style: { display: 'flex' } };
+    context.document = {
+        getElementById(id) {
+            if (id === 'playerInventory') return inventoryList;
+            if (id === 'inventory-item-count') return count;
+            if (id === 'inventory-item-limit') return limit;
+            if (id === 'equipmentInfo') return equipmentInfo;
+            return null;
+        },
+        createElement,
+    };
+    context.t = (key) => key;
+    context.player = {
+        equipped: [],
+        inventory: { consumables: [], equipment: [JSON.stringify(item({ category: 'Sword', type: 'Weapon', attribute: 'Damage' }))], refineStones: 0 },
+        companionCharm: null,
+    };
+
+    evaluate(context, 'showInventory()');
+
+    assert.equal(inventoryList.scrollTop, 120);
+    assert.equal(inventoryList.children.length, 1);
+
+    equipmentInfo.style.display = 'none';
+    inventoryList.scrollTop = 80;
+    evaluate(context, 'showInventory()');
+    assert.equal(inventoryList.scrollTop, 0, 'normal inventory rebuilds should retain their existing reset behavior');
+});
+
 test('accessories are obtainable through normal equipment generation', () => {
     const context = createContext();
     context.player = {


### PR DESCRIPTION
## Why

Opening the currently equipped Companion Charm could make the scrolled inventory list jump upward. A background inventory refresh rebuilt `#playerInventory` while the equipment detail modal was open, which discarded the list's active scroll position.

## Changes

- Preserve the inventory list's `scrollTop` while equipment details are open.
- Restore the saved position after inventory rows are rebuilt.
- Keep the existing scroll reset behavior for normal inventory rebuilds and sorting.
- Add a regression test covering both modal and normal refresh behavior.

## Issue

The jump was especially visible with a longer inventory: clicking the equipped Companion Charm changed the inventory list from `scrollTop = 400` to `242` shortly after the modal opened.

## Testing

- `node --check` for every JavaScript file
- `node --test tests/*.test.js` - 98 tests passed
- `git diff --check`
- Mobile Chrome reproduction at `608x1080`

## Verification

- Before the fix: physical Companion Charm click changed inventory `scrollTop` from `400` to `242`.
- After the fix: the same physical click preserved `400` after one second and opened the equipment detail modal.
- A normal inventory refresh with no equipment detail modal open still resets the list to the top.
