### PR TITLE
fix: open premium purchases directly

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1038,34 +1038,6 @@ button:focus {
     width: 100%;
 }
 
-.forge-unlock-modal {
-    width: min(25rem, calc(100vw - 1rem));
-}
-
-.forge-unlock-options {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-}
-
-.forge-unlock-option {
-    border: 1px solid #565656;
-    border-radius: 0.3rem;
-    padding: 0.65rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.45rem;
-    background: rgba(255, 255, 255, 0.04);
-}
-
-.forge-unlock-option h4 {
-    margin: 0;
-}
-
-.forge-unlock-price {
-    color: #ffd166;
-    font-weight: bold;
-}
 
 .content-ei {
     max-height: 85vh;

--- a/assets/js/automode.js
+++ b/assets/js/automode.js
@@ -93,15 +93,11 @@ if ( !autoModeUnlocked ) {
 const AUTO_MODE_PRODUCT_ID = 'automode_unlock_premium';
 const AUTO_MODE_PURCHASE_URL = 'https://werkstattl.itch.io/quick-dungeon-crawler-on-demand/purchase';
 
-const closeAutoModeUnlockModal = () => {
+const buyPermanentAutoModeUnlock = () => {
     closeDefaultModal();
     if (typeof menuModalElement !== 'undefined' && menuModalElement) {
         menuModalElement.style.display = "flex";
     }
-};
-
-const buyPermanentAutoModeUnlock = () => {
-    closeAutoModeUnlockModal();
     if (isCordova() && typeof buyAutoModeUnlock === 'function') {
         buyAutoModeUnlock();
         return;
@@ -111,96 +107,6 @@ const buyPermanentAutoModeUnlock = () => {
         ratingSystem.openGooglePlayForRating();
     } else {
         openExternal(AUTO_MODE_PURCHASE_URL);
-    }
-};
-
-const buyAutoModeMembershipUnlock = () => {
-    closeAutoModeUnlockModal();
-    if (isCordova() && typeof buyForgeMembership === 'function') {
-        buyForgeMembership();
-        return;
-    }
-
-    if (/Android/i.test(navigator.userAgent)) {
-        ratingSystem.openGooglePlayForRating();
-    } else {
-        openExternal(AUTO_MODE_PURCHASE_URL);
-    }
-};
-
-const openAutoModeUnlockModal = () => {
-    if (typeof defaultModalElement === 'undefined' || !defaultModalElement) {
-        return;
-    }
-
-    sfxOpen.play();
-    if (typeof menuModalElement !== 'undefined' && menuModalElement) {
-        menuModalElement.style.display = "none";
-    }
-    defaultModalElement.style.zIndex = "2";
-    defaultModalElement.style.display = "flex";
-    defaultModalElement.innerHTML = `
-        <div class="content forge-unlock-modal auto-mode-unlock-modal">
-            <div class="content-head">
-                <h3><i class="fas fa-play"></i> <span data-i18n="auto-mode-unlock">Purchase: Auto Mode</span></h3>
-                <p id="auto-mode-unlock-close"><i class="fa fa-xmark"></i></p>
-            </div>
-            <p data-i18n="auto-mode-description">Automatically engage enemies, claim loot and open doors.</p>
-            <div class="forge-unlock-options">
-                <section class="forge-unlock-option">
-                    <h4 data-i18n="forge-permanent-unlock">Permanent Unlock</h4>
-                    <p class="forge-unlock-price" data-i18n="forge-permanent-unlock-price">€2.99 + VAT one-time</p>
-                    <ul class="forge-membership-benefits">
-                        <li data-i18n="forge-permanent-unlock-keep-forever">Keep forever</li>
-                    </ul>
-                    <button id="auto-mode-buy-permanent" type="button" data-i18n="buy-permanently">Buy Permanently</button>
-                </section>
-                <section class="forge-unlock-option">
-                    <h4 data-i18n="forge-membership">The Forge Membership</h4>
-                    <p class="forge-unlock-price" data-i18n="forge-membership-price">€0.99 + VAT / month</p>
-                    <ul class="forge-membership-benefits">
-                        <li data-i18n="forge-membership-benefit-premium">Access to all premium features</li>
-                        <li data-i18n="forge-membership-benefit-inventory">Expanded inventory (+50 slots)</li>
-                        <li data-i18n="forge-membership-benefit-resting">Enhanced resting recovery</li>
-                        <li data-i18n="forge-membership-benefit-gold">10% gold found</li>
-                        <li data-i18n="forge-membership-benefit-title">Exclusive Forge Member title</li>
-                        <li data-i18n="forge-membership-benefit-supports-development">Supports ongoing development</li>
-                    </ul>
-                    <p class="forge-membership-terms" data-i18n="forge-membership-auto-renewing">Auto-renewing subscription</p>
-                    <p class="forge-membership-terms" data-i18n="forge-membership-cancel-google-play">Cancel anytime through Google Play.</p>
-                    <button id="auto-mode-buy-membership" type="button" data-i18n="forge-membership-subscribe">Subscribe</button>
-                </section>
-            </div>
-        </div>`;
-    applyTranslations(defaultModalElement);
-
-    const buyPermanentButton = document.querySelector('#auto-mode-buy-permanent');
-    const buyMembershipButton = document.querySelector('#auto-mode-buy-membership');
-    const closeButton = document.querySelector('#auto-mode-unlock-close');
-
-    if (isForgeMembershipActive() && buyMembershipButton) {
-        buyMembershipButton.disabled = true;
-        buyMembershipButton.setAttribute('data-i18n', 'forge-membership-subscribed');
-        buyMembershipButton.textContent = t('forge-membership-subscribed');
-    }
-
-    if (buyPermanentButton) {
-        buyPermanentButton.onclick = () => {
-            sfxConfirm.play();
-            buyPermanentAutoModeUnlock();
-        };
-    }
-    if (buyMembershipButton) {
-        buyMembershipButton.onclick = () => {
-            sfxConfirm.play();
-            buyAutoModeMembershipUnlock();
-        };
-    }
-    if (closeButton) {
-        closeButton.onclick = () => {
-            sfxDecline.play();
-            closeAutoModeUnlockModal();
-        };
     }
 };
 

--- a/assets/js/forge.js
+++ b/assets/js/forge.js
@@ -40,12 +40,8 @@ const FORGE_CATEGORY_CONFIG = Object.freeze([
     { category: 'Talisman', attribute: 'Utility', type: 'Accessory' },
 ]);
 
-const closeForgeUnlockModal = () => {
-    closeDefaultModal();
-};
-
 const buyPermanentForgeUnlock = () => {
-    closeForgeUnlockModal();
+    closeDefaultModal();
     if (isCordova() && typeof buyForgeUnlock === 'function') {
         buyForgeUnlock();
         return;
@@ -58,99 +54,14 @@ const buyPermanentForgeUnlock = () => {
     }
 };
 
-const buyForgeMembershipUnlock = () => {
-    closeForgeUnlockModal();
-    if (isCordova() && typeof buyForgeMembership === 'function') {
-        buyForgeMembership();
-        return;
-    }
-
-    if (/Android/i.test(navigator.userAgent)) {
-        ratingSystem.openGooglePlayForRating();
-    } else {
-        openExternal(FORGE_PURCHASE_URL);
-    }
-};
-
-const openForgeUnlockModal = () => {
-    if (!defaultModalElement) {
-        return;
-    }
-
-    sfxOpen.play();
-    defaultModalElement.style.zIndex = "2";
-    defaultModalElement.style.display = "flex";
-    defaultModalElement.innerHTML = `
-        <div class="content forge-unlock-modal">
-            <div class="content-head">
-                <h3><i class="ra ra-anvil"></i> <span data-i18n="unlock-the-forge">Unlock The Forge</span></h3>
-                <p id="forge-unlock-close"><i class="fa fa-xmark"></i></p>
-            </div>
-            <div class="forge-unlock-options">
-                <section class="forge-unlock-option">
-                    <h4 data-i18n="forge-permanent-unlock">Permanent Unlock</h4>
-                    <p class="forge-unlock-price" data-i18n="forge-permanent-unlock-price">€2.99 + VAT one-time</p>
-                    <ul class="forge-membership-benefits">
-                        <li data-i18n="forge-permanent-unlock-keep-forever">Keep forever</li>
-                    </ul>
-                    <button id="forge-buy-permanent" type="button" data-i18n="buy-permanently">Buy Permanently</button>
-                </section>
-                <section class="forge-unlock-option">
-                    <h4 data-i18n="forge-membership">The Forge Membership</h4>
-                    <p class="forge-unlock-price" data-i18n="forge-membership-price">€0.99 + VAT / month</p>
-                    <ul class="forge-membership-benefits">
-                        <li data-i18n="forge-membership-benefit-premium">Access to all premium features</li>
-                        <li data-i18n="forge-membership-benefit-inventory">Expanded inventory (+50 slots)</li>
-                        <li data-i18n="forge-membership-benefit-resting">Enhanced resting recovery</li>
-                        <li data-i18n="forge-membership-benefit-gold">10% gold found</li>
-                        <li data-i18n="forge-membership-benefit-title">Exclusive Forge Member title</li>
-                        <li data-i18n="forge-membership-benefit-supports-development">Supports ongoing development</li>
-                    </ul>
-                    <p class="forge-membership-terms" data-i18n="forge-membership-auto-renewing">Auto-renewing subscription</p>
-                    <p class="forge-membership-terms" data-i18n="forge-membership-cancel-google-play">Cancel anytime through Google Play.</p>
-                    <button id="forge-buy-membership" type="button" data-i18n="forge-membership-subscribe">Subscribe</button>
-                </section>
-            </div>
-        </div>`;
-    applyTranslations(defaultModalElement);
-
-    const buyPermanentButton = document.querySelector('#forge-buy-permanent');
-    const buyMembershipButton = document.querySelector('#forge-buy-membership');
-    const closeButton = document.querySelector('#forge-unlock-close');
-    const cancelButton = document.querySelector('#forge-unlock-cancel');
-
-    if (isForgeMembershipActive() && buyMembershipButton) {
-        buyMembershipButton.disabled = true;
-        buyMembershipButton.setAttribute('data-i18n', 'forge-membership-subscribed');
-        buyMembershipButton.textContent = t('forge-membership-subscribed');
-    }
-
-    if (buyPermanentButton) {
-        buyPermanentButton.onclick = () => {
-            sfxConfirm.play();
-            buyPermanentForgeUnlock();
-        };
-    }
-    if (buyMembershipButton) {
-        buyMembershipButton.onclick = () => {
-            sfxConfirm.play();
-            buyForgeMembershipUnlock();
-        };
-    }
-    [closeButton, cancelButton].forEach(button => {
-        if (!button) return;
-        button.onclick = () => {
-            sfxDecline.play();
-            closeForgeUnlockModal();
-        };
-    });
-};
-
 const setForgeUnlockButton = (confirmButton) => {
     confirmButton.disabled = false;
     confirmButton.setAttribute('data-i18n', 'unlock-the-forge-premium');
     confirmButton.textContent = t('unlock-the-forge-premium');
-    confirmButton.onclick = openForgeUnlockModal;
+    confirmButton.onclick = () => {
+        sfxConfirm.play();
+        buyPermanentForgeUnlock();
+    };
 };
 
 // Initialize forge system

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -918,7 +918,8 @@ function openMenu(isTitle = false) {
         if (!autoModeUnlocked) {
             let unlockAuto = document.querySelector('#unlock-auto');
             unlockAuto.onclick = function () {
-                openAutoModeUnlockModal();
+                sfxConfirm.play();
+                buyPermanentAutoModeUnlock();
             };
         }
 

--- a/tests/direct-premium-purchases.test.js
+++ b/tests/direct-premium-purchases.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const forgeSource = fs.readFileSync(path.join(root, 'assets/js/forge.js'), 'utf8');
+const autoModeSource = fs.readFileSync(path.join(root, 'assets/js/automode.js'), 'utf8');
+const mainSource = fs.readFileSync(path.join(root, 'assets/js/main.js'), 'utf8');
+const styleSource = fs.readFileSync(path.join(root, 'assets/css/style.css'), 'utf8');
+
+test('premium unlock controls open the permanent purchase directly', () => {
+    const forgeUnlockButton = forgeSource.match(/const setForgeUnlockButton[\s\S]*?^};/m)?.[0] || '';
+    const autoModeUnlockButton = mainSource.match(/if \(!autoModeUnlocked\)[\s\S]*?^        }/m)?.[0] || '';
+
+    assert.match(forgeUnlockButton, /buyPermanentForgeUnlock\(\)/);
+    assert.match(autoModeUnlockButton, /buyPermanentAutoModeUnlock\(\)/);
+
+    assert.doesNotMatch(forgeSource, /openForgeUnlockModal/);
+    assert.doesNotMatch(autoModeSource, /openAutoModeUnlockModal/);
+    assert.doesNotMatch(forgeSource, /id="forge-buy-permanent"/);
+    assert.doesNotMatch(autoModeSource, /id="auto-mode-buy-permanent"/);
+    assert.doesNotMatch(styleSource, /\.forge-unlock-(?:modal|options?|price)/);
+});


### PR DESCRIPTION
## Why

The Forge and Auto Mode purchase actions do not need an intermediate unlock modal. Players should go directly to the existing permanent-purchase flow.

## Changes

- remove the Forge unlock modal
- remove the Auto Mode unlock modal
- route both locked controls directly to their permanent purchases
- remove obsolete unlock-modal styling and handlers
- keep the separate Forge Membership menu unchanged
- add regression coverage for the direct purchase wiring

## Testing

- `node --test tests/*.test.js` (100 tests passed)
- `node --check` for all 19 files in `assets/js`
- mocked Cordova verification reached `buyForgeUnlock` and `buyAutoModeUnlock`
- browser verification confirmed both modal openers are removed and reported no console errors

## Verification

The Forge and Auto Mode controls now invoke the same permanent-purchase path that their former `Buy Permanently` buttons used.