### PR TITLE
Increase Accessory Dodge roll weight

### DIFF
--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -435,7 +435,7 @@ const EQUIPMENT_REROLL_STAT_POOLS = {
     evasive: ["dodge", "dodge", "luck", "luck", "atkSpd", "critRate"],
     boots: ["dodge", "fasterRun", "hp", "def", "hp", "def"],
     damageDefense: ["hp", "def", "atk", "atk", "critRate", "critDmg", "luck"],
-    utility: ["atk", "hp", "def", "atkSpd", "critRate", "critDmg", "vamp", "dodge", "luck"],
+    utility: ["atk", "hp", "def", "atkSpd", "critRate", "critDmg", "vamp", "dodge", "dodge", "luck"],
 };
 
 const getEquipmentRerollStatPool = (equipment) => {

--- a/tests/equipment-slots.test.js
+++ b/tests/equipment-slots.test.js
@@ -112,6 +112,16 @@ test('accessories are obtainable through normal equipment generation', () => {
     assert.ok(generated.stats.length > 0);
 });
 
+test('accessory rerolls weight Dodge twice in the stat pool', () => {
+    const context = createContext();
+    const dodgeEntries = evaluate(
+        context,
+        "EQUIPMENT_REROLL_STAT_POOLS.utility.filter((stat) => stat === 'dodge').length",
+    );
+
+    assert.equal(dodgeEntries, 2);
+});
+
 test('accessory rerolls never include Faster Run', () => {
     const context = createContext();
     context.player = {


### PR DESCRIPTION
## Why
Accessories currently contain Dodge only once in their utility stat pool, making it less likely to roll than intended.

## Changes
- Add one additional Dodge entry to the Accessory utility reroll pool
- Add a regression test asserting that Dodge appears exactly twice in the pool

## Issue
New Accessories should have a higher chance to roll Dodge without changing the available stats of other item types.

## Testing
- `node --test --test-name-pattern="accessory rerolls weight Dodge" tests/equipment-slots.test.js`
- `node --test tests/*.test.js` (100 tests passed)
- JavaScript syntax checks for tracked and untracked files
- `git diff --check`

## Verification
The focused regression test failed with one Dodge entry before the production change and passed after the second entry was added.