### PR TITLE
Remove obsolete equipment comparison navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -810,70 +810,6 @@ button:focus {
     justify-content: center;
 }
 
-#equipmentInfo .content .equipment-compare-slot--with-nav {
-    display: flex;
-    justify-content: center;
-    width: 100%;
-}
-
-#equipmentInfo .content .equipment-compare-card-slot {
-    display: flex;
-    justify-content: center;
-    width: 100%;
-}
-
-#equipmentInfo .content .equipment-compare-slot--with-nav > .equipment-compare-card-slot {
-    min-width: 0;
-}
-
-#equipmentInfo .content .equipment-compare-slot--with-nav > .equipment-compare-card-slot:only-child {
-    flex: 1 1 auto;
-}
-
-#equipmentInfo .content .equipment-compare-nav {
-    background: rgba(0, 0, 0, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 999px;
-    color: #fff;
-    width: 1.8rem;
-    height: 1.8rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.9rem;
-    cursor: pointer;
-    transition: background 0.2s ease, transform 0.2s ease;
-}
-
-#equipmentInfo .content .equipment-card-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-}
-
-#equipmentInfo .content .equipment-compare-nav-group {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-#equipmentInfo .content .equipment-compare-nav:disabled {
-    opacity: 0.35;
-    cursor: default;
-    transform: none;
-}
-
-#equipmentInfo .content .equipment-compare-nav:not(:disabled):hover {
-    background: rgba(255, 255, 255, 0.12);
-    transform: scale(1.05);
-}
-
-#equipmentInfo .content .equipment-compare-nav:focus-visible {
-    outline: 2px solid rgba(255, 255, 255, 0.6);
-    outline-offset: 2px;
-}
-
 #equipmentInfo .content .equipment-card {
     background: rgba(0, 0, 0, 0.35);
     border: 1px solid rgba(255, 255, 255, 0.1);
@@ -957,14 +893,6 @@ button:focus {
     #equipmentInfo .content.equipment-info-content,
     #equipmentInfo .content.equipment-info-content--with-compare {
         max-width: calc(100vw - 1.5rem);
-    }
-    #equipmentInfo .content .equipment-compare-slot--with-nav {
-        justify-content: center;
-    }
-    #equipmentInfo .content .equipment-compare-nav {
-        width: 1.6rem;
-        height: 1.6rem;
-        font-size: 0.85rem;
     }
 }
 

--- a/assets/js/equipment.js
+++ b/assets/js/equipment.js
@@ -791,17 +791,10 @@ const showItemInfo = (item, icon, action, i) => {
     const lockButtonMarkup = `<button id="toggle-lock">${lockButtonLabel}</button>`;
     itemInfo.style.display = "flex";
     const itemSlot = getEquipmentSlot(item);
-    const equippedItems = action === 'equip'
-        ? [getEquippedItemForSlot(itemSlot)].filter(Boolean)
-        : (action === 'equip-companion' && getEquippedCompanionCharm() ? [getEquippedCompanionCharm()] : []);
-    let comparisonIndex = 0;
-    if (isEquipAction && equippedItems.length > 0) {
-        const initialComparison = action === 'equip-companion'
-            ? equippedItems[0]
-            : findComparableEquippedItem(item);
-        const initialIndex = initialComparison ? equippedItems.indexOf(initialComparison) : -1;
-        comparisonIndex = initialIndex >= 0 ? initialIndex : 0;
-    }
+    const comparisonItem = action === 'equip'
+        ? findComparableEquippedItem(item)
+        : (action === 'equip-companion' ? getEquippedCompanionCharm() : null);
+    const comparisonTotals = comparisonItem ? getEquipmentStatTotals(comparisonItem) : null;
     const selectedTotals = getEquipmentStatTotals(item);
     const selectedLabelFallback = action === 'equip'
         ? 'Inventory Item'
@@ -810,7 +803,7 @@ const showItemInfo = (item, icon, action, i) => {
             : action === 'unequip-companion'
                 ? 'Equipped Charm'
                 : 'Equipped Item';
-    const renderSelectedCard = (comparisonTotals = null) => renderEquipmentCard({
+    const renderSelectedCard = () => renderEquipmentCard({
         item,
         icon,
         totals: selectedTotals,
@@ -818,22 +811,15 @@ const showItemInfo = (item, icon, action, i) => {
         labelFallback: selectedLabelFallback,
         highlightDiff: Boolean(comparisonTotals)
     });
-    const hasComparisonItems = isEquipAction && equippedItems.length > 0;
-    let prevLabel = '';
-    let nextLabel = '';
+    const hasComparisonItem = isEquipAction && Boolean(comparisonItem);
     let comparisonSection = renderSelectedCard();
     if (isEquipAction) {
-        prevLabel = translateEquipText('previous-equipped-item', 'Previous equipped item');
-        nextLabel = translateEquipText('next-equipped-item', 'Next equipped item');
         comparisonSection = `
             <div class="equipment-compare-grid">
                 <div id="equipment-selected-card" class="equipment-compare-slot"></div>
-                ${hasComparisonItems ? `
-                <div class="equipment-compare-slot equipment-compare-slot--with-nav">
-                    <div id="equipment-comparison-card" class="equipment-compare-card-slot"></div>
-                </div>` : ''}
+                ${hasComparisonItem ? '<div id="equipment-comparison-card" class="equipment-compare-slot"></div>' : ''}
             </div>`;
-        if (!hasComparisonItems) {
+        if (!hasComparisonItem) {
             const hintKey = isCompanionAction
                 ? 'no-companion-charm'
                 : (player.equipped.length > 0 ? 'no-comparable-item' : 'no-equipped-items');
@@ -853,7 +839,7 @@ const showItemInfo = (item, icon, action, i) => {
     const sellButtonDisabled = isLocked ? ' disabled' : '';
     const sellButtonTitle = isLocked ? ` title="${lockedSellLabel}"` : '';
     itemInfo.innerHTML = `
-            <div class="content equipment-info-content${hasComparisonItems ? ' equipment-info-content--with-compare' : ''}">
+            <div class="content equipment-info-content${hasComparisonItem ? ' equipment-info-content--with-compare' : ''}">
                 ${comparisonSection}
                 <div class="button-container">
                     <button id="un-equip">${actionLabel}</button>
@@ -866,64 +852,23 @@ const showItemInfo = (item, icon, action, i) => {
     if (isEquipAction) {
         const selectedCardContainer = itemInfo.querySelector('#equipment-selected-card');
         const comparisonCardContainer = itemInfo.querySelector('#equipment-comparison-card');
-        const updateComparisonDisplay = () => {
-            let comparisonTotals = null;
-            let comparisonItem = null;
-            if (equippedItems.length > 0) {
-                comparisonIndex = ((comparisonIndex % equippedItems.length) + equippedItems.length) % equippedItems.length;
-                comparisonItem = equippedItems[comparisonIndex];
-                comparisonTotals = getEquipmentStatTotals(comparisonItem);
-            }
-            if (selectedCardContainer) {
-                selectedCardContainer.innerHTML = renderSelectedCard(comparisonTotals);
-            }
-            if (comparisonCardContainer) {
-                if (comparisonItem && comparisonTotals) {
-                    const comparisonIcon = equipmentIcon(comparisonItem.baseCategory || comparisonItem.category);
-                    const baseLabel = isCompanionAction
-                        ? 'Currently Equipped Charm'
-                        : translateEquipText('currently-equipped', 'Currently Equipped');
-                    const label = equippedItems.length > 1 ? `${baseLabel} (${comparisonIndex + 1}/${equippedItems.length})` : baseLabel;
-                    const navMarkup = equippedItems.length > 1 && !isCompanionAction ? `
-                        <div class="equipment-compare-nav-group">
-                            <button type="button" class="equipment-compare-nav equipment-compare-nav--prev" aria-label="${prevLabel}" title="${prevLabel}"${equippedItems.length <= 1 ? ' disabled' : ''}>&#9664;</button>
-                            <button type="button" class="equipment-compare-nav equipment-compare-nav--next" aria-label="${nextLabel}" title="${nextLabel}"${equippedItems.length <= 1 ? ' disabled' : ''}>&#9654;</button>
-                        </div>` : '';
-                    const comparisonCard = renderEquipmentCard({
-                        item: comparisonItem,
-                        icon: comparisonIcon,
-                        totals: comparisonTotals,
-                        comparisonTotals: selectedTotals,
-                        labelFallback: label,
-                        highlightDiff: false,
-                        headerActions: navMarkup
-                    });
-                    comparisonCardContainer.innerHTML = comparisonCard;
-                } else {
-                    comparisonCardContainer.innerHTML = '';
-                }
-            }
-        };
-        if (comparisonCardContainer) {
-            comparisonCardContainer.addEventListener('click', (event) => {
-                const button = event.target.closest('.equipment-compare-nav');
-                if (!button || button.disabled) {
-                    return;
-                }
-                if (!equippedItems.length) {
-                    return;
-                }
-                if (button.classList.contains('equipment-compare-nav--prev')) {
-                    comparisonIndex = (comparisonIndex - 1 + equippedItems.length) % equippedItems.length;
-                } else if (button.classList.contains('equipment-compare-nav--next')) {
-                    comparisonIndex = (comparisonIndex + 1) % equippedItems.length;
-                } else {
-                    return;
-                }
-                updateComparisonDisplay();
+        if (selectedCardContainer) {
+            selectedCardContainer.innerHTML = renderSelectedCard();
+        }
+        if (comparisonCardContainer && comparisonItem && comparisonTotals) {
+            const comparisonIcon = equipmentIcon(comparisonItem.baseCategory || comparisonItem.category);
+            const label = isCompanionAction
+                ? 'Currently Equipped Charm'
+                : translateEquipText('currently-equipped', 'Currently Equipped');
+            comparisonCardContainer.innerHTML = renderEquipmentCard({
+                item: comparisonItem,
+                icon: comparisonIcon,
+                totals: comparisonTotals,
+                comparisonTotals: selectedTotals,
+                labelFallback: label,
+                highlightDiff: false
             });
         }
-        updateComparisonDisplay();
     }
 
     // Equip/Unequip button for the item
@@ -1567,7 +1512,7 @@ const getOrderedEquipmentStats = (primaryTotals, comparisonTotals) => {
     return ordered.concat(remaining);
 };
 
-const renderEquipmentCard = ({ item, icon, totals, comparisonTotals = null, labelKey = '', labelFallback = '', highlightDiff = false, headerActions = '' }) => {
+const renderEquipmentCard = ({ item, icon, totals, comparisonTotals = null, labelKey = '', labelFallback = '', highlightDiff = false }) => {
     const label = labelKey ? translateEquipText(labelKey, labelFallback || labelKey) : (labelFallback || '');
     const tier = item.tier === undefined ? 1 : item.tier;
     const statKeys = getOrderedEquipmentStats(totals, comparisonTotals);
@@ -1585,14 +1530,7 @@ const renderEquipmentCard = ({ item, icon, totals, comparisonTotals = null, labe
                 </li>`;
     }).join('');
     const statsList = statsMarkup || `<li class="equipment-stat-row"><span class="stat-name">${translateEquipText('no-stats-available', 'No stats available')}</span></li>`;
-    let headerMarkup = '';
-    if (label) {
-        headerMarkup = headerActions ? `
-            <div class="equipment-card-header">
-                <p class="equipment-card-label">${label}</p>
-                ${headerActions}
-            </div>` : `<p class="equipment-card-label">${label}</p>`;
-    }
+    const headerMarkup = label ? `<p class="equipment-card-label">${label}</p>` : '';
     return `
         <div class="equipment-card">
             ${headerMarkup}

--- a/tests/equipment-slots.test.js
+++ b/tests/equipment-slots.test.js
@@ -83,6 +83,17 @@ test('opening companion charm details does not focus or filter the inventory scr
     assert.match(styleSource, /#equipmentInfo,[^{]*{[^}]*background-color:/s);
 });
 
+test('fixed-slot item comparison has no unreachable multi-item navigation', () => {
+    const showItemInfoSource = equipmentSource.slice(
+        equipmentSource.indexOf('const showItemInfo ='),
+        equipmentSource.indexOf('// Sort inventory'),
+    );
+
+    assert.doesNotMatch(showItemInfoSource, /\bcomparisonIndex\b|previous-equipped-item|next-equipped-item|equipment-compare-nav/);
+    assert.doesNotMatch(equipmentSource, /headerActions|equipment-card-header/);
+    assert.doesNotMatch(styleSource, /equipment-compare-nav|equipment-compare-slot--with-nav|equipment-card-header/);
+});
+
 test('accessories are obtainable through normal equipment generation', () => {
     const context = createContext();
     context.player = {


### PR DESCRIPTION
## Why

The fixed equipment-slot system allows only one equipped comparison item per slot. The previous/next comparison controls can therefore never be displayed and have become unreachable legacy code.

## Changes

- replace the single-element comparison array and index state with one `comparisonItem`
- remove previous/next markup, click handlers, counters, and navigation-only card rendering
- remove orphaned navigation and card-header CSS
- preserve normal same-slot and Companion Charm comparisons
- add a regression test that prevents the obsolete navigation code from returning

## Issue

The comparison modal still carried navigation designed for multiple equipped items of the same type, even though fixed slots make that state impossible.

## Testing

- `node --test tests/*.test.js` - 104/104 tests passed
- `node --check` - all 35 JavaScript files passed
- `git diff --check`

## Verification

- tested a generated inventory weapon against an equipped weapon in the browser
- both comparison cards remained visible
- zero comparison navigation controls were rendered
- no browser console errors
- independent review found no blocking issues and marked the change safe to commit