### PR TITLE
feat(balance): scale blessing costs by Curse

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -63,6 +63,7 @@ const WANDERING_SHOP_FLOOR = 6;
 const WANDERING_SHOP_MIN_RARITY = 'Rare';
 const FORGE_TOKEN_MERCHANT_FLOOR = 13;
 const FORGE_TOKEN_MERCHANT_COST = 10000;
+const BLESSING_CURSE_COST_STEP = 0.05;
 let lastDungeonEventTimestamp = Date.now();
 
 let dungeon = {
@@ -217,6 +218,13 @@ const shouldTriggerForgeTokenMerchant = () => {
 
 const getWanderingShopCost = () => {
     return Math.round(((WANDERING_SHOP_FLOOR * 500) + (player.lvl * 150)) * player.selectedCurseLevel);
+};
+
+const getBlessingCost = (blessingLevel, curseLevel) => {
+    const baseCost = blessingLevel * (500 * (blessingLevel * 0.5)) + 750;
+    const normalizedCurseLevel = clampCurseLevel(curseLevel);
+    const curseMultiplier = 1 + ((normalizedCurseLevel - MIN_CURSE_LEVEL) * BLESSING_CURSE_COST_STEP);
+    return Math.round(baseCost * curseMultiplier);
 };
 
 const getDungeonStoryBeatKey = (floor) => {
@@ -760,7 +768,7 @@ const dungeonEvent = () => {
                     dungeon.status.event = true;
                     dungeon.roomEvents.blessingOccurred = true;
                     blessingValidation();
-                    let cost = player.blessing * (500 * (player.blessing * 0.5)) + 750;
+                    let cost = getBlessingCost(player.blessing, player.selectedCurseLevel);
                     choices = `
                         <div class="decision-panel">
                             <button id="choice1">${t('offer')}</button>

--- a/tests/blessing-costs.test.js
+++ b/tests/blessing-costs.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const progressionSource = fs.readFileSync(path.join(root, 'assets/js/progression.js'), 'utf8');
+const dungeonSource = fs.readFileSync(path.join(root, 'assets/js/dungeon.js'), 'utf8');
+
+const context = vm.createContext({
+    console,
+    Date,
+    localStorage: { getItem() { return null; } },
+    document: {
+        querySelector() {
+            return {
+                addEventListener() {},
+                appendChild() {},
+                insertBefore() {},
+                querySelectorAll() { return []; },
+            };
+        },
+        createElement() { return { innerHTML: '' }; },
+    },
+});
+vm.runInContext(progressionSource, context);
+vm.runInContext(dungeonSource, context);
+
+const evaluate = (expression) => vm.runInContext(expression, context);
+
+test('Curse 1 retains the existing blessing cost curve', () => {
+    assert.equal(evaluate('getBlessingCost(1, 1)'), 1000);
+    assert.equal(evaluate('getBlessingCost(2, 1)'), 1750);
+});
+
+test('blessing costs increase by five percent for each Curse above 1', () => {
+    assert.equal(evaluate('getBlessingCost(1, 5)'), 1200);
+    assert.equal(evaluate('getBlessingCost(1, 10)'), 1450);
+    assert.equal(evaluate('getBlessingCost(1, 15)'), 1700);
+});
+
+test('scaled blessing costs are rounded to whole gold', () => {
+    assert.equal(evaluate('getBlessingCost(2, 10)'), 2538);
+});
+
+test('the blessing event uses the selected Curse level', () => {
+    assert.match(
+        dungeonSource,
+        /getBlessingCost\(player\.blessing, player\.selectedCurseLevel\)/,
+    );
+});


### PR DESCRIPTION
## Why
Higher Curse Levels generate more gold, making Blessings progressively cheaper relative to the run economy when their price only scales with Blessing level.

## Changes
- Keep the existing Blessing price curve unchanged on Curse 1
- Increase Blessing prices by 5% for each Curse Level above 1
- Use the player's selected Curse Level when calculating the live event cost
- Round scaled prices to whole gold

## Issue
Blessing prices did not account for the increased gold income at higher Curse Levels.

## Testing
- `node --test tests/*.test.js` (118 passed)
- `node --check` for all tracked and untracked JavaScript files
- Browser smoke test on the actual branch: Curse 1 = 1000, Curse 10 = 1450, Curse 15 = 1700; no console errors

## Verification
- Curse 1 prices remain backward compatible
- Curse 5 costs 20% more than Curse 1
- Curse 10 costs 45% more than Curse 1
- Curse 15 costs 70% more than Curse 1
