### PR TITLE
Fix recovery from inconsistent combat saves

### DIFF
--- a/assets/js/enemy.js
+++ b/assets/js/enemy.js
@@ -1,5 +1,5 @@
 // Enemy
-let enemy = {
+const createEmptyEnemyState = () => ({
     id: null,
     name: null,
     type: null,
@@ -27,6 +27,13 @@ let enemy = {
         gold: null,
         drop: null
     }
+});
+
+let enemy = createEmptyEnemyState();
+
+const resetEnemyState = () => {
+    enemy = createEmptyEnemyState();
+    return enemy;
 };
 
 // Data for all enemies keyed by ID
@@ -122,6 +129,71 @@ const enemyPools = {
         guardian: [42, 31, 32],
         sboss: [48]
     }
+};
+
+const isSavedEnemyValidForDungeon = (candidate, savedDungeon, savedPlayer) => {
+    if (!candidate || typeof candidate !== 'object') {
+        return false;
+    }
+    if (!Number.isInteger(candidate.id) || !enemyData[candidate.id]) {
+        return false;
+    }
+    if (!Object.prototype.hasOwnProperty.call(enemyPools, candidate.type)) {
+        return false;
+    }
+    if (!Number.isFinite(candidate.lvl) || candidate.lvl < 1) {
+        return false;
+    }
+    if (!candidate.stats || typeof candidate.stats !== 'object') {
+        return false;
+    }
+    const requiredStats = ['hp', 'hpMax', 'atk', 'def', 'atkSpd', 'vamp', 'critRate', 'critDmg', 'dodge'];
+    if (requiredStats.some((stat) => !Number.isFinite(candidate.stats[stat]))) {
+        return false;
+    }
+    if (candidate.stats.hp <= 0 || candidate.stats.hpMax <= 0
+        || candidate.stats.hp > candidate.stats.hpMax
+        || candidate.stats.atk < 0 || candidate.stats.def < 0 || candidate.stats.atkSpd <= 0
+        || candidate.stats.vamp < 0 || candidate.stats.critRate < 0
+        || candidate.stats.critDmg < 0 || candidate.stats.dodge < 0) {
+        return false;
+    }
+
+    const canonicalEnemy = enemyData[candidate.id];
+    const canonicalSprites = Array.isArray(canonicalEnemy.sprite)
+        ? canonicalEnemy.sprite
+        : [canonicalEnemy.sprite];
+    const canonicalSize = canonicalEnemy.size || '50%';
+    if (!candidate.image || !canonicalSprites.includes(candidate.image.name)
+        || candidate.image.size !== canonicalSize) {
+        return false;
+    }
+    if (!candidate.rewards || !Number.isFinite(candidate.rewards.exp)
+        || !Number.isFinite(candidate.rewards.gold)
+        || candidate.rewards.exp < 0 || candidate.rewards.gold < 0
+        || typeof candidate.rewards.drop !== 'boolean') {
+        return false;
+    }
+
+    const floor = savedDungeon && savedDungeon.progress && savedDungeon.progress.floor;
+    const settings = savedDungeon && savedDungeon.settings;
+    if (!Number.isFinite(floor) || floor < 1 || !settings) {
+        return false;
+    }
+    if (!Number.isFinite(settings.enemyLvlGap) || settings.enemyLvlGap < 1
+        || !Number.isFinite(settings.enemyBaseLvl)) {
+        return false;
+    }
+    const maxGeneratedLevel = floor * settings.enemyLvlGap + (settings.enemyBaseLvl - 1);
+    const minGeneratedLevel = maxGeneratedLevel - (settings.enemyLvlGap - 1);
+    const levelOneAdjustment = savedPlayer && savedPlayer.lvl === 1 ? 2 : 0;
+    const minLevel = minGeneratedLevel > 3
+        ? minGeneratedLevel - levelOneAdjustment
+        : minGeneratedLevel;
+    const maxLevel = maxGeneratedLevel > 3
+        ? maxGeneratedLevel - levelOneAdjustment
+        : maxGeneratedLevel;
+    return candidate.lvl >= minLevel && candidate.lvl <= maxLevel;
 };
 
 const generateRandomEnemy = (condition) => {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,6 +10,30 @@ const migratePlayerEquipmentSlots = () => {
     return migration;
 };
 
+const restoreSavedCombatState = () => {
+    if (!player || !player.inCombat) {
+        return false;
+    }
+
+    const savedEnemy = safeLoad(STORAGE_KEYS.enemy, STORAGE_KEYS.enemyBackup);
+    if (typeof isSavedEnemyValidForDungeon !== 'function'
+        || !isSavedEnemyValidForDungeon(savedEnemy, dungeon, player)) {
+        player.inCombat = false;
+        if (typeof resetEnemyState === 'function') {
+            resetEnemyState();
+        }
+        return false;
+    }
+
+    enemy = savedEnemy;
+    enemy.stats.hpPercent = Math.max(0, Math.min(100,
+        (enemy.stats.hp / enemy.stats.hpMax) * 100));
+    if (typeof ensureEnemyAffixState === 'function') {
+        ensureEnemyAffixState();
+    }
+    return true;
+};
+
 // Use DOMContentLoaded so interactions are available as soon as the DOM is ready
 // rather than waiting for all assets to finish loading
 window.addEventListener("DOMContentLoaded", async function () {
@@ -1142,20 +1166,20 @@ const enterDungeon = () => {
     document.querySelector("#title-screen").style.display = "none";
     runLoad("dungeon-main", "flex");
     initCompanions();
-    if (player.inCombat) {
-        enemy = JSON.parse(localStorage.getItem("enemyData"));
-        if (typeof ensureEnemyAffixState === 'function') {
-            ensureEnemyAffixState();
-        }
+    initialDungeonLoad();
+    const hadSavedCombat = player.inCombat;
+    if (restoreSavedCombatState()) {
         showCombatInfo();
         startCombat(bgmBattleMain);
     } else {
+        if (hadSavedCombat) {
+            saveData();
+        }
         bgmDungeon.play();
     }
     if (player.stats.hp == 0) {
         progressReset(true);
     }
-    initialDungeonLoad();
     grantEquipmentSlotMigrationAccessory(equipmentSlotMigrationNoticePending);
     addNewRunIntroLog();
     playerLoadStats();
@@ -1168,7 +1192,7 @@ const enterDungeon = () => {
 // Save all the data into local storage
 let isSaving = false;
 let lastSaveTime = Date.now();
-const saveData = () => {
+const saveData = ({ forceDungeon = false } = {}) => {
     if (isSaving) return; // Prevent overlapping saves
     isSaving = true;
     try {
@@ -1185,7 +1209,8 @@ const saveData = () => {
         // Only save if all data is valid JSON
         const playerSaved = safeSave(STORAGE_KEYS.player, player, STORAGE_KEYS.playerBackup, STORAGE_KEYS.playerTemp);
         const existingDungeonData = localStorage.getItem("dungeonData");
-        const canPersistDungeon = dungeon && (dungeon.initialized || existingDungeonData === null);
+        const canPersistDungeon = dungeon
+            && (forceDungeon || dungeon.initialized || existingDungeonData === null);
         if (canPersistDungeon) {
             safeSave(STORAGE_KEYS.dungeon, dungeon, STORAGE_KEYS.dungeonBackup, STORAGE_KEYS.dungeonTemp);
         }
@@ -1434,6 +1459,9 @@ const progressReset = (fromDeath = false) => {
     dungeon.action = 0;
     dungeon.nothingBias = 0;
     combatBacklog.length = 0;
+    if (typeof resetEnemyState === 'function') {
+        resetEnemyState();
+    }
     playerCompanions = [];
     activeCompanion = null;
     if (typeof grantStartingCompanions === 'function') {
@@ -1441,7 +1469,7 @@ const progressReset = (fromDeath = false) => {
     } else {
         saveCompanions();
     }
-    saveData();
+    saveData({ forceDungeon: true });
 }
 
 const formatRunDuration = (seconds) => {

--- a/tests/combat-resume-recovery.test.js
+++ b/tests/combat-resume-recovery.test.js
@@ -1,0 +1,209 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const mainSource = fs.readFileSync(path.join(root, 'assets/js/main.js'), 'utf8');
+const startupHelpersSource = mainSource.split('// Use DOMContentLoaded')[0];
+const saveDataSource = mainSource.slice(
+    mainSource.indexOf('let isSaving = false;'),
+    mainSource.indexOf('const maybeUnlockNextCurseLevel')
+);
+const enemySource = fs.readFileSync(path.join(root, 'assets/js/enemy.js'), 'utf8');
+
+const createDungeon = (floor = 1) => ({
+    progress: { floor },
+    settings: { enemyBaseLvl: 1, enemyLvlGap: 5 },
+});
+
+const createEnemy = (level = 3) => ({
+    id: 1,
+    name: 'Goblin',
+    type: 'Balanced',
+    lvl: level,
+    condition: null,
+    affixes: [],
+    phase: { index: 0 },
+    stats: {
+        hp: 100,
+        hpMax: 100,
+        atk: 10,
+        def: 5,
+        atkSpd: 0.4,
+        vamp: 0,
+        critRate: 1,
+        critDmg: 50,
+        dodge: 0,
+    },
+    image: { name: 'goblin', size: '50%' },
+    rewards: { exp: 10, gold: 5, drop: false },
+});
+
+const createSaveContext = () => {
+    const savedValues = new Map();
+    const context = vm.createContext({
+        console,
+        Date,
+        player: { lvl: 1 },
+        dungeon: { initialized: false, progress: { floor: 1, room: 1 } },
+        enemy: { id: null },
+        STORAGE_KEYS: {
+            player: 'playerData',
+            playerBackup: 'playerData_backup',
+            playerTemp: 'playerData_temp',
+            dungeon: 'dungeonData',
+            dungeonBackup: 'dungeonData_backup',
+            dungeonTemp: 'dungeonData_temp',
+            enemy: 'enemyData',
+            enemyBackup: 'enemyData_backup',
+            enemyTemp: 'enemyData_temp',
+        },
+        localStorage: {
+            getItem: (key) => key === 'dungeonData' ? '{"progress":{"floor":7,"room":3}}' : null,
+        },
+        safeSave: (key, value) => {
+            savedValues.set(key, JSON.parse(JSON.stringify(value)));
+            return true;
+        },
+    });
+    vm.runInContext(saveDataSource, context);
+    return { context, savedValues };
+};
+
+const createStartupContext = ({ savedEnemy, floor = 1, playerLevel = 1 } = {}) => {
+    const context = vm.createContext({
+        console,
+        player: { inCombat: true, lvl: playerLevel },
+        dungeon: createDungeon(floor),
+        savedEnemy: savedEnemy ?? null,
+        staleEnemy: createEnemy(33),
+        STORAGE_KEYS: {
+            enemy: 'enemyData',
+            enemyBackup: 'enemyData_backup',
+        },
+        safeLoad: () => context.savedEnemy,
+    });
+    vm.runInContext(enemySource, context);
+    vm.runInContext('enemy = staleEnemy', context);
+    vm.runInContext(startupHelpersSource, context);
+    return context;
+};
+
+test('missing enemy data cancels combat resume without abandoning the run', () => {
+    const context = createStartupContext({ savedEnemy: null });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, false);
+    assert.equal(context.player.inCombat, false);
+    assert.equal(vm.runInContext('enemy.id', context), null);
+    assert.equal(vm.runInContext('enemy.lvl', context), null);
+});
+
+test('stale enemy from a later floor is rejected during combat resume', () => {
+    const context = createStartupContext({ savedEnemy: createEnemy(33), floor: 1 });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, false);
+    assert.equal(context.player.inCombat, false);
+    assert.equal(vm.runInContext('enemy.id', context), null);
+});
+
+test('stale enemy from an earlier floor is rejected during combat resume', () => {
+    const context = createStartupContext({ savedEnemy: createEnemy(3), floor: 7, playerLevel: 10 });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, false);
+    assert.equal(context.player.inCombat, false);
+});
+
+test('enemy data with invalid combat values is rejected', () => {
+    const malformedEnemy = createEnemy(3);
+    malformedEnemy.stats.hp = -5;
+    malformedEnemy.stats.hpMax = 0;
+    malformedEnemy.stats.atkSpd = -1;
+    malformedEnemy.rewards.gold = -10;
+    const context = createStartupContext({ savedEnemy: malformedEnemy });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, false);
+    assert.equal(context.player.inCombat, false);
+});
+
+test('enemy data with non-canonical image attributes is rejected', () => {
+    const malformedEnemy = createEnemy(3);
+    malformedEnemy.image.name = 'goblin\" onerror=\"alert(1)';
+    malformedEnemy.image.size = '100%\" onload=\"alert(1)';
+    const context = createStartupContext({ savedEnemy: malformedEnemy });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, false);
+    assert.equal(context.player.inCombat, false);
+});
+
+test('saved hp percentage is recomputed before combat rendering', () => {
+    const savedEnemy = createEnemy(3);
+    savedEnemy.stats.hp = 25;
+    savedEnemy.stats.hpMax = 100;
+    savedEnemy.stats.hpPercent = '</div><img src=x onerror=alert(1)>';
+    const context = createStartupContext({ savedEnemy, floor: 1 });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, true);
+    assert.equal(vm.runInContext('enemy.stats.hpPercent', context), 25);
+});
+
+test('valid enemy data resumes combat', () => {
+    const savedEnemy = createEnemy(3);
+    const context = createStartupContext({ savedEnemy, floor: 1 });
+
+    const resumed = vm.runInContext('restoreSavedCombatState()', context);
+
+    assert.equal(resumed, true);
+    assert.equal(context.player.inCombat, true);
+    assert.equal(vm.runInContext('enemy.id', context), savedEnemy.id);
+    assert.equal(vm.runInContext('enemy.lvl', context), savedEnemy.lvl);
+});
+
+test('enemy reset replaces stale combat state with an empty enemy', () => {
+    const context = vm.createContext({ console });
+    vm.runInContext(enemySource, context);
+
+    vm.runInContext('enemy.lvl = 33; enemy.id = 1; resetEnemyState()', context);
+    const resetEnemy = vm.runInContext('enemy', context);
+
+    assert.equal(resetEnemy.id, null);
+    assert.equal(resetEnemy.lvl, null);
+    assert.equal(resetEnemy.type, null);
+    assert.equal(Array.isArray(resetEnemy.affixes), true);
+    assert.equal(resetEnemy.affixes.length, 0);
+});
+
+test('ordinary saves preserve the startup guard for an uninitialized dungeon', () => {
+    const { context, savedValues } = createSaveContext();
+
+    vm.runInContext('saveData()', context);
+
+    assert.equal(savedValues.has('playerData'), true);
+    assert.equal(savedValues.has('enemyData'), true);
+    assert.equal(savedValues.has('dungeonData'), false);
+});
+
+test('forced save persists a reset dungeon before normal initialization', () => {
+    const { context, savedValues } = createSaveContext();
+
+    vm.runInContext('saveData({ forceDungeon: true })', context);
+
+    assert.deepEqual(savedValues.get('dungeonData').progress, { floor: 1, room: 1 });
+});
+
+test('new-run reset forces the reset dungeon to replace stale saved progress', () => {
+    assert.match(mainSource, /const progressReset[\s\S]*?resetEnemyState\(\)[\s\S]*?saveData\(\{ forceDungeon: true \}\)/);
+});


### PR DESCRIPTION
## Why

A player reported that closing the app during combat could leave the saved player, dungeon, and enemy state out of sync. Resuming with missing enemy data produced an empty, stuck dungeon screen, while stale enemy data could carry a Level 33 enemy into a new Floor 1 run.

Report: https://www.reddit.com/r/QuickDungeonCrawler/comments/1vl41zm/startup_bug/

## Changes

- Load saved enemy data through the existing safe-storage recovery path.
- Validate saved enemy structure and level against the restored dungeon before resuming combat.
- Cancel only the invalid combat state while preserving the current run.
- Restore the dungeon before rebuilding a valid combat encounter.
- Clear enemy state whenever a run is reset.
- Force an intentional run reset to replace stale dungeon progress even if startup failed before dungeon initialization, while preserving the normal startup save guard.
- Add regression coverage for missing, stale, valid, and reset enemy states, plus forced and ordinary dungeon persistence.

## Issue

`playerData`, `dungeonData`, and `enemyData` are persisted separately. If an app shutdown interrupts those writes, `player.inCombat` can disagree with the saved enemy. The previous startup path parsed `enemyData` directly and assumed it was valid.

## Testing

- `node --test tests/combat-resume-recovery.test.js`
- `node --test tests/*.test.js`
- `for f in assets/js/*.js tests/*.js; do node --check "$f" || exit 1; done`

## Verification

Browser-tested all three startup states:

- Missing enemy data recovers to Floor 1 / Room 1 without a JavaScript error.
- A stale Level 33 enemy saved for Floor 1 is discarded and combat is cancelled safely.
- A valid Level 3 Floor 1 enemy resumes the combat panel normally.
- Resetting from the failed startup path replaces stale Floor 7 / Room 3 dungeon data with Floor 1 / Room 1.

Local suite: **129/129 tests passed**.
