### PR TITLE
Fix Forge Token merchant eligibility

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -212,7 +212,8 @@ const shouldTriggerWanderingShop = () => {
 
 const shouldTriggerForgeTokenMerchant = () => {
     ensureSpecialEventsState();
-    return dungeon.progress.floor === FORGE_TOKEN_MERCHANT_FLOOR
+    return !forgeUnlocked
+        && dungeon.progress.floor === FORGE_TOKEN_MERCHANT_FLOOR
         && !dungeon.specialEvents.floor13ForgeTokenMerchantVisited;
 };
 

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -48,6 +48,7 @@ const createDungeonContext = () => {
         sfxDeny: { play() {} },
         playerLoadStats() {},
         saveData() {},
+        forgeUnlocked: false,
     });
     vm.runInContext(dungeonSource, context);
     context.addDungeonLog = () => {};
@@ -81,6 +82,14 @@ test('the Forge Token merchant is forced once on Floor 13 each run', () => {
     evaluate(context, 'resetSpecialEvents()');
     assert.equal(evaluate(context, 'shouldTriggerForgeTokenMerchant()'), true);
     setDungeonState(context, { floor: 12 });
+    assert.equal(evaluate(context, 'shouldTriggerForgeTokenMerchant()'), false);
+});
+
+test('the Forge Token merchant is hidden from players with an unlocked Forge', () => {
+    const context = createDungeonContext();
+    setDungeonState(context);
+    context.forgeUnlocked = true;
+
     assert.equal(evaluate(context, 'shouldTriggerForgeTokenMerchant()'), false);
 });
 


### PR DESCRIPTION
## Why
The Floor 13 Forge Token merchant offers limited Forge access, so players who already have the Forge unlocked should not encounter an offer they cannot meaningfully use.

## Changes
- Require the Forge to be locked before triggering the Floor 13 Forge Token merchant.
- Preserve the existing Floor 13 and once-per-run eligibility rules.
- Add regression coverage for unlocked Forge players.

## Issue
Players with an unlocked Forge could still encounter the Forge Token merchant on Floor 13.

## Testing
- `node --test tests/forge-tokens.test.js`
- `node --test tests/*.test.js` (130/130 passed)
- `node --check` for all shipped and test JavaScript files
- `git diff --check`

## Verification
Verified in the browser that the merchant is eligible on Floor 13 while the Forge is locked and ineligible after the Forge is unlocked.
