### PR TITLE
fix: charge gold for Forge Token actions

### DIFF
--- a/assets/js/forge.js
+++ b/assets/js/forge.js
@@ -53,19 +53,17 @@ const ensureForgeTokenInventory = () => {
 
 const getForgeTokenCount = () => ensureForgeTokenInventory();
 const hasForgeToken = () => getForgeTokenCount() > 0;
-const getForgeActionGoldCost = (goldCost) => hasForgeToken() ? 0 : goldCost;
+const getForgeActionGoldCost = (goldCost) => goldCost;
 const hasForgeActionAccess = () => forgeUnlocked || hasForgeToken();
-const canPayForgeAction = (goldCost) => hasForgeActionAccess()
-    && (hasForgeToken() || player.gold >= goldCost);
+const canPayForgeAction = (goldCost) => hasForgeActionAccess() && player.gold >= goldCost;
 
 const payForForgeAction = (goldCost) => {
     if (!canPayForgeAction(goldCost)) {
         return false;
     }
-    if (hasForgeToken()) {
+    player.gold -= goldCost;
+    if (!forgeUnlocked) {
         player.inventory.forgeTokens -= 1;
-    } else {
-        player.gold -= goldCost;
     }
     return true;
 };

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -144,13 +144,23 @@ test('old saves normalize Forge Tokens to a non-negative integer', () => {
     assert.equal(evaluate(context, 'ensureForgeTokenInventory()'), 0);
 });
 
-test('a free player can spend one token for access and zero gold cost', () => {
-    const context = createForgeContext({ unlocked: false, gold: 0, tokens: 2 });
+test('a free player spends one token for access and still pays the normal gold cost', () => {
+    const context = createForgeContext({ unlocked: false, gold: 5000, tokens: 2 });
     assert.equal(evaluate(context, 'hasForgeActionAccess()'), true);
-    assert.equal(evaluate(context, 'canPayForgeAction(999999)'), true);
-    assert.equal(evaluate(context, 'payForForgeAction(999999)'), true);
-    assert.equal(context.player.gold, 0);
+    assert.equal(evaluate(context, 'getForgeActionGoldCost(1200)'), 1200);
+    assert.equal(evaluate(context, 'canPayForgeAction(1200)'), true);
+    assert.equal(evaluate(context, 'payForForgeAction(1200)'), true);
+    assert.equal(context.player.gold, 3800);
     assert.equal(context.player.inventory.forgeTokens, 1);
+});
+
+test('a Forge Token does not bypass insufficient gold', () => {
+    const context = createForgeContext({ unlocked: false, gold: 1199, tokens: 2 });
+
+    assert.equal(evaluate(context, 'canPayForgeAction(1200)'), false);
+    assert.equal(evaluate(context, 'payForForgeAction(1200)'), false);
+    assert.equal(context.player.gold, 1199);
+    assert.equal(context.player.inventory.forgeTokens, 2);
 });
 
 test('Merge, Reroll, and Refine all use the shared token-aware payment path', () => {
@@ -171,21 +181,13 @@ test('Merge, Reroll, and Refine all use the shared token-aware payment path', ()
     assert.match(refineBody, /player\.inventory\.refineStones -= refineStoneCost/);
 });
 
-test('a Forge owner automatically spends tokens before gold', () => {
+test('a Forge owner pays gold without spending tokens', () => {
     const context = createForgeContext({ unlocked: true, gold: 5000, tokens: 2 });
 
-    assert.equal(evaluate(context, 'getForgeActionGoldCost(1200)'), 0);
-    assert.equal(evaluate(context, 'payForForgeAction(1200)'), true);
-    assert.equal(context.player.gold, 5000);
-    assert.equal(context.player.inventory.forgeTokens, 1);
-
-    assert.equal(evaluate(context, 'payForForgeAction(999999)'), true);
-    assert.equal(context.player.gold, 5000);
-    assert.equal(context.player.inventory.forgeTokens, 0);
     assert.equal(evaluate(context, 'getForgeActionGoldCost(1200)'), 1200);
-
     assert.equal(evaluate(context, 'payForForgeAction(1200)'), true);
     assert.equal(context.player.gold, 3800);
+    assert.equal(context.player.inventory.forgeTokens, 2);
 });
 
 test('Forge Token count and save defaults are wired without a payment checkbox', () => {


### PR DESCRIPTION
## Why
Forge Tokens should grant limited access to The Forge, not waive the normal gold cost.

## Changes
- Keep the regular gold cost for Merge, Reroll, and Refine when a token grants access
- Consume one token only for players without an unlocked Forge
- Prevent token actions when the player cannot afford the gold cost
- Preserve tokens for permanent Forge owners and active Forge members

## Testing
- `node --test tests/forge-tokens.test.js`
- `node --test tests/*.test.js` (130 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`
