### PR TITLE
fix: hide Forge Tokens from unlocked players

### DIFF
--- a/assets/js/forge.js
+++ b/assets/js/forge.js
@@ -234,7 +234,10 @@ function unlockForge() {
 const updateForgeGold = () => {
     if (forgeGoldElement) {
         const refineStoneCount = typeof getRefineStoneCount === 'function' ? getRefineStoneCount() : 0;
-        forgeGoldElement.innerHTML = `<i class="fas fa-coins" style="color: #FFD700;"></i>${nFormatter(player.gold)} <span class="forge-material-count"><i class="ra ra-crystal-ball"></i>${nFormatter(refineStoneCount)}</span> <span class="forge-material-count" title="${t('forge-tokens')}"><i class="ra ra-anvil"></i>${nFormatter(getForgeTokenCount())}</span>`;
+        const forgeTokenCount = forgeUnlocked
+            ? ''
+            : ` <span class="forge-material-count" title="${t('forge-tokens')}"><i class="ra ra-anvil"></i>${nFormatter(getForgeTokenCount())}</span>`;
+        forgeGoldElement.innerHTML = `<i class="fas fa-coins" style="color: #FFD700;"></i>${nFormatter(player.gold)} <span class="forge-material-count"><i class="ra ra-crystal-ball"></i>${nFormatter(refineStoneCount)}</span>${forgeTokenCount}`;
     }
 };
 

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -199,6 +199,20 @@ test('a Forge owner pays gold without spending tokens', () => {
     assert.equal(context.player.inventory.forgeTokens, 2);
 });
 
+test('the Forge hides the token count from players with unlocked access', () => {
+    const context = createForgeContext({ unlocked: true, gold: 5000, tokens: 2 });
+    context.forgeGold = { innerHTML: '' };
+    context.nFormatter = (value) => String(value);
+    context.t = (key) => key;
+    context.getRefineStoneCount = () => 3;
+    evaluate(context, 'forgeGoldElement = forgeGold; updateForgeGold();');
+
+    assert.match(context.forgeGold.innerHTML, />5000/);
+    assert.match(context.forgeGold.innerHTML, />3<\/span>/);
+    assert.doesNotMatch(context.forgeGold.innerHTML, /forge-tokens/);
+    assert.doesNotMatch(context.forgeGold.innerHTML, /ra-anvil/);
+});
+
 test('Forge Token count and save defaults are wired without a payment checkbox', () => {
     assert.doesNotMatch(indexSource, /id="forge-use-token"/);
     assert.doesNotMatch(forgeSource, /useForgeToken/);


### PR DESCRIPTION
## Why
Forge Tokens only grant Forge access to players without an unlock. Showing the unused token count to permanent owners or active members is confusing.

## Changes
- Hide the Forge Token counter while the Forge is unlocked
- Keep stored tokens unchanged in the save
- Continue showing gold and Refine Stones normally
- Add regression coverage for the unlocked Forge display

## Testing
- `node --test tests/forge-tokens.test.js` (13 tests)
- `node --test tests/*.test.js` (132 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`
