### PR TITLE
fix: let Auto Mode buy merchant offers

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -991,7 +991,7 @@ const wanderingShopEvent = () => {
     document.querySelector("#choice2").onclick = function () {
         ignoreEvent();
     };
-    autoDecline();
+    autoConfirm();
 }
 
 const forgeTokenMerchantEvent = () => {
@@ -1033,7 +1033,7 @@ const forgeTokenMerchantEvent = () => {
     document.querySelector("#choice2").onclick = function () {
         ignoreEvent();
     };
-    autoDecline();
+    autoConfirm();
 }
 
 // Non choices dungeon event messages

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -43,6 +43,7 @@ const createDungeonContext = () => {
             return String(value);
         },
         addDungeonLog() {},
+        autoConfirm() {},
         autoDecline() {},
         sfxSell: { play() {} },
         sfxDeny: { play() {} },
@@ -69,6 +70,22 @@ const setDungeonState = (context, { floor = 13, gold = 10000, tokens = 0, visite
         dungeon.specialEvents.floor13ForgeTokenMerchantVisited = ${visited};
     `);
 };
+
+test('Auto Mode buys from both wandering merchants', () => {
+    const wanderingShopBody = dungeonSource.slice(
+        dungeonSource.indexOf('const wanderingShopEvent ='),
+        dungeonSource.indexOf('const forgeTokenMerchantEvent =')
+    );
+    const forgeTokenMerchantBody = dungeonSource.slice(
+        dungeonSource.indexOf('const forgeTokenMerchantEvent ='),
+        dungeonSource.indexOf('const nothingEvent =')
+    );
+
+    for (const body of [wanderingShopBody, forgeTokenMerchantBody]) {
+        assert.match(body, /autoConfirm\(\)/);
+        assert.doesNotMatch(body, /autoDecline\(\)/);
+    }
+});
 
 test('the Forge Token merchant is forced once on Floor 13 each run', () => {
     const context = createDungeonContext();


### PR DESCRIPTION
## Why
Auto Mode currently ignores both wandering merchant offers, even when the player has enough gold.

## Changes
- Auto-confirm the Floor 6 Wandering Merchant purchase
- Auto-confirm the Floor 13 Forge Token Merchant purchase
- Preserve each merchant's existing insufficient-gold behavior
- Add regression coverage for both merchant event handlers

## Testing
- `node --test tests/forge-tokens.test.js` (14 tests)
- `node --test tests/*.test.js` (133 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`
