### PR TITLE
feat: scale Wandering Merchant gear with progress

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -217,8 +217,32 @@ const shouldTriggerForgeTokenMerchant = () => {
         && !dungeon.specialEvents.floor13ForgeTokenMerchantVisited;
 };
 
+const getWanderingShopLevelRange = () => {
+    const floorMaximum = clampEquipmentLevel(
+        WANDERING_SHOP_FLOOR * dungeon.settings.enemyLvlGap + (dungeon.settings.enemyBaseLvl - 1)
+    );
+    const floorMinimum = clampEquipmentLevel(floorMaximum - (dungeon.settings.enemyLvlGap - 1));
+    const equippedLevels = Array.isArray(player.equipped)
+        ? player.equipped
+            .map((item) => Number(item && item.lvl))
+            .filter((level) => Number.isFinite(level) && level > 0)
+        : [];
+    if (equippedLevels.length < 6) {
+        return { minimum: floorMinimum, maximum: floorMaximum };
+    }
+
+    const weakestEquippedLevel = Math.min(...equippedLevels);
+    return {
+        minimum: Math.max(floorMinimum, clampEquipmentLevel(weakestEquippedLevel - 5)),
+        maximum: Math.max(floorMaximum, clampEquipmentLevel(weakestEquippedLevel + 5)),
+    };
+};
+
 const getWanderingShopCost = () => {
-    return Math.round(((WANDERING_SHOP_FLOOR * 500) + (player.lvl * 150)) * player.selectedCurseLevel);
+    const baseCost = ((WANDERING_SHOP_FLOOR * 500) + (player.lvl * 150)) * player.selectedCurseLevel;
+    const floorMaximum = WANDERING_SHOP_FLOOR * dungeon.settings.enemyLvlGap + (dungeon.settings.enemyBaseLvl - 1);
+    const offerMaximum = getWanderingShopLevelRange().maximum;
+    return Math.round(baseCost * (offerMaximum / floorMaximum));
 };
 
 const getBlessingCost = (blessingLevel, curseLevel) => {
@@ -962,6 +986,7 @@ const wanderingShopEvent = () => {
     ensureSpecialEventsState();
     dungeon.specialEvents.floor6WanderingShopVisited = true;
     const cost = getWanderingShopCost();
+    const itemLevelRange = getWanderingShopLevelRange();
     const choices = `
         <div class="decision-panel">
             <button id="choice1" data-i18n="buy">${t('buy')}</button>
@@ -982,6 +1007,7 @@ const wanderingShopEvent = () => {
         createEquipmentPrint("dungeon", {
             allowCompanionCharm: false,
             minRarity: WANDERING_SHOP_MIN_RARITY,
+            forcedLevel: randomizeNum(itemLevelRange.minimum, itemLevelRange.maximum),
             messageKey: 'wandering-shop-item-received',
         });
         playerLoadStats();

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -222,9 +222,22 @@ const getWanderingShopLevelRange = () => {
         WANDERING_SHOP_FLOOR * dungeon.settings.enemyLvlGap + (dungeon.settings.enemyBaseLvl - 1)
     );
     const floorMinimum = clampEquipmentLevel(floorMaximum - (dungeon.settings.enemyLvlGap - 1));
+    const currentCurseLevel = Number(player.selectedCurseLevel);
     const equippedLevels = Array.isArray(player.equipped)
         ? player.equipped
-            .map((item) => Number(item && item.lvl))
+            .map((item) => {
+                const level = Number(item && item.lvl);
+                if (!Number.isFinite(level) || level <= 0) {
+                    return null;
+                }
+                const tier = Number(item && item.tier);
+                const tierPenalty = Number.isFinite(tier)
+                    && Number.isFinite(currentCurseLevel)
+                    && tier < currentCurseLevel
+                    ? 10
+                    : 0;
+                return Math.max(1, level - tierPenalty);
+            })
             .filter((level) => Number.isFinite(level) && level > 0)
         : [];
     if (equippedLevels.length < 6) {

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -231,10 +231,12 @@ const getWanderingShopLevelRange = () => {
         return { minimum: floorMinimum, maximum: floorMaximum };
     }
 
-    const weakestEquippedLevel = Math.min(...equippedLevels);
+    const averageEquippedLevel = Math.round(
+        equippedLevels.reduce((total, level) => total + level, 0) / equippedLevels.length
+    );
     return {
-        minimum: Math.max(floorMinimum, clampEquipmentLevel(weakestEquippedLevel - 5)),
-        maximum: Math.max(floorMaximum, clampEquipmentLevel(weakestEquippedLevel + 5)),
+        minimum: Math.max(floorMinimum, clampEquipmentLevel(averageEquippedLevel - 5)),
+        maximum: Math.max(floorMaximum, clampEquipmentLevel(averageEquippedLevel + 5)),
     };
 };
 

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -93,6 +93,63 @@ test('the Wandering Merchant scales its item level around the rounded average eq
     assert.equal(evaluate(context, 'getWanderingShopCost()'), 660000);
 });
 
+test('the Wandering Merchant subtracts ten levels from below-Curse equipment before averaging', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.selectedCurseLevel = 11;
+    context.player.equipped = [
+        { lvl: 80, tier: 10 },
+        { lvl: 80, tier: 10 },
+        { lvl: 80, tier: 11 },
+        { lvl: 80, tier: 11 },
+        { lvl: 80, tier: 11 },
+        { lvl: 80, tier: 11 },
+    ];
+
+    assert.deepEqual(
+        JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+        { minimum: 72, maximum: 82 }
+    );
+});
+
+for (const [label, invalidLevel] of [
+    ['null', null],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['zero', 0],
+    ['negative', -1],
+]) {
+    test(`the Wandering Merchant excludes a ${label} raw item level from six-slot detection`, () => {
+        const context = createDungeonContext();
+        setDungeonState(context, { floor: 6 });
+        context.player.selectedCurseLevel = 11;
+        context.player.equipped = [
+            ...Array.from({ length: 5 }, () => ({ lvl: 100, tier: 11 })),
+            { lvl: invalidLevel, tier: 10 },
+        ];
+
+        assert.deepEqual(
+            JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+            { minimum: 26, maximum: 30 }
+        );
+    });
+}
+
+test('the Wandering Merchant floors a penalized positive item level at one', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.selectedCurseLevel = 11;
+    context.player.equipped = [
+        { lvl: 1, tier: 10 },
+        ...Array.from({ length: 5 }, () => ({ lvl: 40, tier: 11 })),
+    ];
+
+    assert.deepEqual(
+        JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+        { minimum: 29, maximum: 39 }
+    );
+});
+
 test('the Wandering Merchant keeps its Floor 6 item levels for early progression', () => {
     const context = createDungeonContext();
     setDungeonState(context, { floor: 6 });

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -79,7 +79,7 @@ const setDungeonState = (context, { floor = 13, gold = 10000, tokens = 0, visite
     `);
 };
 
-test('the Wandering Merchant scales its item level around the weakest equipped item', () => {
+test('the Wandering Merchant scales its item level around the rounded average equipped level', () => {
     const context = createDungeonContext();
     setDungeonState(context, { floor: 6 });
     context.player.lvl = 100;
@@ -88,9 +88,9 @@ test('the Wandering Merchant scales its item level around the weakest equipped i
 
     assert.deepEqual(
         JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
-        { minimum: 86, maximum: 96 }
+        { minimum: 91, maximum: 100 }
     );
-    assert.equal(evaluate(context, 'getWanderingShopCost()'), 633600);
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 660000);
 });
 
 test('the Wandering Merchant keeps its Floor 6 item levels for early progression', () => {
@@ -148,10 +148,10 @@ test('the Wandering Merchant purchase generates an item inside the scaled range'
         condition: 'dungeon',
         allowCompanionCharm: false,
         minRarity: 'Rare',
-        forcedLevel: 96,
+        forcedLevel: 100,
         messageKey: 'wandering-shop-item-received',
     });
-    assert.equal(context.player.gold, 366400);
+    assert.equal(context.player.gold, 340000);
 });
 
 test('Auto Mode buys from both wandering merchants', () => {

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -50,6 +50,14 @@ const createDungeonContext = () => {
         playerLoadStats() {},
         saveData() {},
         forgeUnlocked: false,
+        MAX_EQUIPMENT_LEVEL: 100,
+        clampEquipmentLevel(value) {
+            return Math.min(100, Math.max(1, Math.round(Number(value) || 1)));
+        },
+        randomizeNum(minimum, maximum) {
+            return Math.floor(Math.random() * (maximum - minimum + 1)) + minimum;
+        },
+        createEquipmentPrint() {},
     });
     vm.runInContext(dungeonSource, context);
     context.addDungeonLog = () => {};
@@ -70,6 +78,81 @@ const setDungeonState = (context, { floor = 13, gold = 10000, tokens = 0, visite
         dungeon.specialEvents.floor13ForgeTokenMerchantVisited = ${visited};
     `);
 };
+
+test('the Wandering Merchant scales its item level around the weakest equipped item', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.lvl = 100;
+    context.player.selectedCurseLevel = 11;
+    context.player.equipped = [91, 94, 96, 97, 99, 100].map((lvl) => ({ lvl }));
+
+    assert.deepEqual(
+        JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+        { minimum: 86, maximum: 96 }
+    );
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 633600);
+});
+
+test('the Wandering Merchant keeps its Floor 6 item levels for early progression', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.lvl = 20;
+    context.player.selectedCurseLevel = 1;
+    context.player.equipped = [{ lvl: 12 }, { lvl: 25 }];
+
+    assert.deepEqual(
+        JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+        { minimum: 26, maximum: 30 }
+    );
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 6000);
+});
+
+test('the Wandering Merchant keeps Floor 6 levels until all six equipment slots are filled', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.equipped = [96, 97, 98, 99, 100].map((lvl) => ({ lvl }));
+
+    assert.deepEqual(
+        JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+        { minimum: 26, maximum: 30 }
+    );
+});
+
+test('the Wandering Merchant caps progression-scaled item levels at 100', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.equipped = Array.from({ length: 6 }, () => ({ lvl: 100 }));
+
+    assert.deepEqual(
+        JSON.parse(evaluate(context, 'JSON.stringify(getWanderingShopLevelRange())')),
+        { minimum: 95, maximum: 100 }
+    );
+});
+
+test('the Wandering Merchant purchase generates an item inside the scaled range', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6, gold: 1000000 });
+    context.player.lvl = 100;
+    context.player.selectedCurseLevel = 11;
+    context.player.equipped = [91, 94, 96, 97, 99, 100].map((lvl) => ({ lvl }));
+    context.merchantItemOptions = null;
+    context.randomizeNum = (minimum, maximum) => maximum;
+    context.createEquipmentPrint = (condition, options) => {
+        context.merchantItemOptions = { condition, ...options };
+    };
+
+    evaluate(context, 'wanderingShopEvent()');
+    context.buttons['#choice1'].onclick();
+
+    assert.deepEqual(context.merchantItemOptions, {
+        condition: 'dungeon',
+        allowCompanionCharm: false,
+        minRarity: 'Rare',
+        forcedLevel: 96,
+        messageKey: 'wandering-shop-item-received',
+    });
+    assert.equal(context.player.gold, 366400);
+});
 
 test('Auto Mode buys from both wandering merchants', () => {
     const wanderingShopBody = dungeonSource.slice(


### PR DESCRIPTION
## Why
The Floor 6 Wandering Merchant currently sells Level 26-30 equipment even to endgame players with Level 90+ gear, making the offer irrelevant.

## Changes
- Keep the existing Level 26-30 offer until all six equipment slots are filled
- Once all slots are filled, scale the offer around the rounded average equipped item level (`average - 5` through `average + 5`), matching the Forge averaging approach
- Before averaging, subtract 10 effective levels from each equipped item whose tier is below the current Curse Level
- Floor penalized valid item levels at 1 and exclude invalid or non-positive item levels from six-slot detection
- Preserve the Level 100 cap and the existing current-Curse equipment tier
- Keep the Rare-or-better rarity guarantee and exclude Companion Charms
- Scale the gold price in proportion to the offer's maximum item level
- Preserve Auto Mode purchasing behavior

## Examples
- Levels 91, 94, 96, 97, 99, and 100 on Curse 11 average to Level 96 when their tiers are current, producing a Level 91-100 offer
- A Level 80 Tier 10 item counts as effective Level 70 on Curse 11 before averaging

## Testing
- `node --test tests/forge-tokens.test.js` (26 tests)
- `node --test tests/*.test.js` (145 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`
- Independent review, fix cycle, and clean re-review