### PR TITLE
feat: add Discord link to game menu

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -926,6 +926,11 @@ button:focus {
     padding: 0;
 }
 
+#discord-link {
+    background: #5865f2;
+    color: #fff;
+}
+
 /* Default Modal */
 #defaultModal .content-head {
     padding: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -467,6 +467,7 @@ function openMenu(isTitle = false) {
             ${isTitle ? '<button id="hero-return"><i class="fas fa-user-circle"></i> <span data-i18n="hero-creation">Hero Creation</span></button>' : '<button id="quit-run"><i class="fas fa-door-open"></i> <span data-i18n="abandon">Abandon</span></button>'}
             <button id="forge-membership"><i class="fas fa-hammer"></i> <span data-i18n="forge-membership">The Forge Membership</span></button>
             <button id="rate-game"><i class="fas fa-star"></i> <span data-i18n="rate-game">Rate Game</span> <i class="fas fa-arrow-up-right-from-square external-link-icon"></i></button>
+            <button id="discord-link"><i class="fab fa-discord"></i> Discord <i class="fas fa-arrow-up-right-from-square external-link-icon"></i></button>
             <button id="reddit-link" style="background:#ff4500;color:#fff;"><i class="fab fa-reddit"></i> <span data-i18n="subreddit">Subreddit</span> <i class="fas fa-arrow-up-right-from-square external-link-icon"></i></button>
         </div>`;
     applyTranslations();
@@ -480,8 +481,14 @@ function openMenu(isTitle = false) {
     let volumeSettings = document.querySelector('#volume-btn');
     let autoModeSettings = document.querySelector('#auto-mode-settings');
     let forgeMembership = document.querySelector('#forge-membership');
+    let discordLink = document.querySelector('#discord-link');
     let redditLink = document.querySelector('#reddit-link');
     let rateGameBtn = document.querySelector('#rate-game');
+    // Discord button click function
+    discordLink.onclick = function () {
+        openExternal('https://discord.gg/U4DvQT3qfQ');
+    }
+
     // Reddit button click function
     redditLink.onclick = function () {
         openExternal('https://www.reddit.com/r/QuickDungeonCrawler/');

--- a/tests/discord-menu-link.test.js
+++ b/tests/discord-menu-link.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const mainSource = fs.readFileSync(path.join(root, 'assets/js/main.js'), 'utf8');
+
+const DISCORD_INVITE_URL = 'https://discord.gg/U4DvQT3qfQ';
+
+test('menu renders an external Discord community button', () => {
+    assert.match(mainSource, /<button id="discord-link"[^>]*>/);
+    assert.match(mainSource, /id="discord-link"[^>]*>[\s\S]*?fa-discord[\s\S]*?Discord[\s\S]*?external-link-icon[\s\S]*?<\/button>/);
+});
+
+test('Discord menu button opens the official invite externally', () => {
+    assert.match(mainSource, /document\.querySelector\('#discord-link'\)/);
+    assert.match(
+        mainSource,
+        new RegExp(`discordLink\\.onclick\\s*=\\s*function\\s*\\(\\)\\s*\\{[\\s\\S]*?openExternal\\('${DISCORD_INVITE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'\\);[\\s\\S]*?\\}`),
+    );
+});


### PR DESCRIPTION
## Why
The new official Discord server should be directly accessible to players from the game.

## Changes
- Add a Discord-branded button to the main game menu
- Open the official Discord invite through the existing external-link helper
- Add regression coverage for button rendering and URL wiring

## Testing
- `node --test tests/*.test.js` (135 tests passed)
- `node --check assets/js/main.js`

## Verification
- Verified the menu visually in the browser in German
- Verified the Discord button opens `https://discord.gg/U4DvQT3qfQ` with the `_system` target
- Verified the invite currently resolves successfully