### PR TITLE
fix: require full gear for merchant scaling

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -247,6 +247,9 @@ const getWanderingShopItemTier = () => {
 // Keeps the offer relevant for players whose gear outscales the current floor
 const getWanderingShopItemLevel = () => {
     const floorLevel = (dungeon.progress.floor * dungeon.settings.enemyLvlGap) + (dungeon.settings.enemyBaseLvl - 1);
+    if (typeof hasCompleteEquipmentLoadout !== 'function' || !hasCompleteEquipmentLoadout()) {
+        return typeof clampEquipmentLevel === 'function' ? clampEquipmentLevel(floorLevel) : floorLevel;
+    }
     // A higher tier is already an upgrade on its own, so trade tier gaps for levels
     const tierGap = Math.max(0, getWanderingShopItemTier() - getEquippedMedian('tier'));
     const gearLevel = getEquippedMedian('lvl') - (tierGap * WANDERING_SHOP_TIER_GAP_LEVEL_PENALTY);

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -50,6 +50,7 @@ const createDungeonContext = () => {
         playerLoadStats() {},
         saveData() {},
         forgeUnlocked: false,
+        hasCompleteEquipmentLoadout() { return false; },
     });
     vm.runInContext(dungeonSource, context);
     context.addDungeonLog = () => {};
@@ -70,6 +71,22 @@ const setDungeonState = (context, { floor = 13, gold = 10000, tokens = 0, visite
         dungeon.specialEvents.floor13ForgeTokenMerchantVisited = ${visited};
     `);
 };
+
+test('the Wandering Merchant scales from gear only with all six equipment slots filled', () => {
+    const context = createDungeonContext();
+    setDungeonState(context, { floor: 6 });
+    context.player.lvl = 100;
+    context.player.selectedCurseLevel = 1;
+    context.player.equipped = Array.from({ length: 6 }, () => ({ lvl: 100, tier: 1 }));
+
+    context.hasCompleteEquipmentLoadout = () => false;
+    assert.equal(evaluate(context, 'getWanderingShopItemLevel()'), 30);
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 18000);
+
+    context.hasCompleteEquipmentLoadout = () => true;
+    assert.equal(evaluate(context, 'getWanderingShopItemLevel()'), 100);
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 25000);
+});
 
 test('Auto Mode buys from both wandering merchants', () => {
     const wanderingShopBody = dungeonSource.slice(


### PR DESCRIPTION
## Why
Dynamic Wandering Merchant scaling can currently be triggered with only one high-level equipped item because the median accepts any non-empty equipment set. Players can unequip the remaining items and still receive an inflated offer.

## Changes
- Require the existing slot-aware complete-loadout check before applying gear-based merchant scaling
- Fall back to the normal Floor 6 item level when any of the six named equipment slots is empty
- Keep the price calculation tied to the resulting fallback or scaled item level
- Fail safely to Floor 6 scaling if the loadout helper is unavailable

## Issue
A Level 100 player on Curse 1 with an incomplete loadout could receive a Level 100 offer for 25,000 gold. After this fix, an incomplete loadout receives the normal Level 30 offer for 18,000 gold.

## Testing
- `node --test tests/forge-tokens.test.js` (15 tests)
- `node --test tests/*.test.js` (136 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`

## Verification
- Confirmed incomplete loadouts return Level 30 and cost 18,000 gold at player Level 100 / Curse 1
- Confirmed complete six-slot loadouts retain Level 100 and cost 25,000 gold in the same scenario
- Independent code review passed