### PR TITLE
balance: increase Wandering Merchant price multiplier

### DIFF
--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -62,6 +62,7 @@ const DUNGEON_TIMER_TICK_MS = 100;
 const WANDERING_SHOP_FLOOR = 6;
 const WANDERING_SHOP_MIN_RARITY = 'Rare';
 const WANDERING_SHOP_COST_PER_LEVEL = 300;
+const WANDERING_SHOP_COST_MULTIPLIER = 1.5;
 const WANDERING_SHOP_TIER_GAP_LEVEL_PENALTY = 10;
 const FORGE_TOKEN_MERCHANT_FLOOR = 13;
 const FORGE_TOKEN_MERCHANT_COST = 10000;
@@ -258,7 +259,7 @@ const getWanderingShopItemLevel = () => {
 };
 
 const getWanderingShopCost = (itemLevel = getWanderingShopItemLevel()) => {
-    return Math.round(((itemLevel * WANDERING_SHOP_COST_PER_LEVEL) + (player.lvl * 150)) * player.selectedCurseLevel);
+    return Math.round(((itemLevel * WANDERING_SHOP_COST_PER_LEVEL) + (player.lvl * 150)) * player.selectedCurseLevel * WANDERING_SHOP_COST_MULTIPLIER);
 };
 
 const getBlessingCost = (blessingLevel, curseLevel) => {

--- a/tests/forge-tokens.test.js
+++ b/tests/forge-tokens.test.js
@@ -81,11 +81,14 @@ test('the Wandering Merchant scales from gear only with all six equipment slots 
 
     context.hasCompleteEquipmentLoadout = () => false;
     assert.equal(evaluate(context, 'getWanderingShopItemLevel()'), 30);
-    assert.equal(evaluate(context, 'getWanderingShopCost()'), 12750);
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 19125);
 
     context.hasCompleteEquipmentLoadout = () => true;
     assert.equal(evaluate(context, 'getWanderingShopItemLevel()'), 100);
-    assert.equal(evaluate(context, 'getWanderingShopCost()'), 33750);
+    assert.equal(evaluate(context, 'getWanderingShopCost()'), 50625);
+
+    context.player.selectedCurseLevel = 10;
+    assert.equal(evaluate(context, 'getWanderingShopCost(80)'), 416250);
 });
 
 test('Auto Mode buys from both wandering merchants', () => {


### PR DESCRIPTION
## Why
Wandering Merchant offers remain too inexpensive after the item-level coefficient increase, particularly for high-value gear at higher Curse Levels.

## Changes
- Add a global 1.5 Wandering Merchant price multiplier
- Keep the item-level coefficient at 300
- Keep the player-level coefficient at 150
- Keep the existing selected-Curse multiplier
- Add an explicit Curse 10 regression assertion

## Examples
At the Floor 6 reference player Level 25:
- Level 30 / Curse 1: 19,125 gold
- Level 100 / Curse 1: 50,625 gold
- Level 80 / Curse 10: 416,250 gold

## Testing
- `node --test tests/forge-tokens.test.js` (15 tests)
- `node --test tests/*.test.js` (136 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`

## Verification
- Confirmed RED before implementation and GREEN afterward
- Verified all example prices directly against the updated formula
- Independent code review passed