### PR TITLE
balance: reduce Enraged attack bonus

### DIFF
--- a/assets/js/affixes.js
+++ b/assets/js/affixes.js
@@ -24,7 +24,7 @@ const AFFIX_ENEMY_ATKSPD_CAP = 2.75;
 
 // mult = multiplicative on the rolled stat, flat = added after. behavior is handled in combat.js.
 const ENEMY_AFFIXES = [
-    { id: 'enraged', behavior: null, mult: { atk: 1.40, hpMax: 0.80 }, flat: null },
+    { id: 'enraged', behavior: null, mult: { atk: 1.35, hpMax: 0.80 }, flat: null },
     { id: 'armored', behavior: null, mult: { def: 1.60, atkSpd: 0.85 }, flat: null },
     { id: 'swift', behavior: null, mult: { atkSpd: 1.35, hpMax: 0.85 }, flat: null },
     { id: 'vampiric', behavior: null, mult: null, flat: { vamp: 20 } },

--- a/tests/enemy-affixes.test.js
+++ b/tests/enemy-affixes.test.js
@@ -161,6 +161,15 @@ test('affix stats respect the enemy dodge and attack speed caps', () => {
     assert.ok(result.atkSpd <= 2.75, `atkSpd ${result.atkSpd} exceeded the cap`);
 });
 
+test('Enraged trades thirty-five percent more attack for twenty percent less health', () => {
+    const context = createAffixContext();
+    context.__stats = { hpMax: 1000, atk: 100, def: 50, atkSpd: 1.5, dodge: 10, vamp: 0 };
+    const result = vm.runInContext(`applyAffixStats(__stats, ['enraged'])`, context);
+
+    assert.equal(result.atk, 135);
+    assert.equal(result.hpMax, 800);
+});
+
 test('applying no affixes leaves stats untouched', () => {
     const context = createAffixContext();
     context.__stats = { hpMax: 1000, atk: 100, def: 50, atkSpd: 1.5, dodge: 10, vamp: 0 };


### PR DESCRIPTION
## Why
Enraged can become overly punishing when combined with a Guardian phase and a critical hit at high Curse Levels. A small reduction keeps Curse 10 dangerous without overreacting to one extreme combination.

## Changes
- Reduce the Enraged Attack multiplier from 1.40 to 1.35
- Keep the Enraged maximum-HP multiplier at 0.80
- Leave Guardian phase Attack and Attack Speed multipliers unchanged
- Add an exact regression test for the Enraged tradeoff

## Balance impact
- Enraged alone: +35% Attack and -20% maximum HP
- Enraged plus Guardian phase: 1.35 x 1.25 = 1.6875x Attack instead of 1.75x
- This is about 3.6% less Attack than the current combined Enraged value

## Testing
- `node --test tests/enemy-affixes.test.js` (35 tests)
- `node --test tests/*.test.js` (137 tests)
- `node --check` for all files in `assets/js` and `tests`
- `git diff --check`

## Verification
- Confirmed RED before implementation and GREEN afterward
- Independent code review passed