### PR TITLE
fix: respect Android safe areas in modals

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,6 +3,19 @@
     --font-scale: 1;
     --base-font-size: 1rem;
     --font-family-base: 'Germania One', Georgia, 'Times New Roman', serif;
+    --modal-safe-max-height: calc(100vh - 1rem);
+}
+
+@supports (padding-top: env(safe-area-inset-top)) {
+    :root {
+        --modal-safe-max-height: calc(100vh - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) - 1rem);
+    }
+}
+
+@supports (height: 100dvh) {
+    :root {
+        --modal-safe-max-height: calc(100dvh - var(--safe-area-inset-top, env(safe-area-inset-top, 0px)) - var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)) - 1rem);
+    }
 }
 
 * {
@@ -647,11 +660,27 @@ button:focus {
 .modal-container {
     display: none;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     position: fixed;
     z-index: 1;
-    width: 100vw;
-    height: 100vh;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    padding: 0.5rem 0;
+    overflow-y: auto;
+}
+
+/* Safe-area-capable modal placement */
+@supports (padding-top: env(safe-area-inset-top)) {
+    .modal-container {
+        top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+        right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
+        bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+        left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
+    }
 }
 
 .modal-container .content {
@@ -665,7 +694,10 @@ button:focus {
     display: flex;
     flex-direction: column;
     gap: 0.5em;
-    margin: 0.5rem;
+    margin: auto 0.5rem;
+    box-sizing: border-box;
+    max-height: var(--modal-safe-max-height);
+    overflow-y: auto;
     -webkit-border-radius: 0.3rem;
     -moz-border-radius: 0.3rem;
     -ms-border-radius: 0.3rem;
@@ -797,7 +829,7 @@ button:focus {
 #equipmentInfo .content.equipment-info-content--with-compare {
     max-width: 48rem;
     overflow-y: auto;
-    max-height: 100vh;
+    max-height: var(--modal-safe-max-height);
 }
 
 #equipmentInfo .content .equipment-compare-grid {
@@ -906,8 +938,7 @@ button:focus {
     padding: 0;
     gap: 0;
     height: 43rem;
-    max-height: calc(100vh - 1rem);
-    max-height: calc(100dvh - 1rem);
+    max-height: var(--modal-safe-max-height);
     width: 16rem;
     overflow-y: auto;
 }
@@ -920,7 +951,7 @@ button:focus {
 #menuModal .content {
     min-width: 15rem;
     overflow-y: auto;
-    max-height: 100vh;
+    max-height: var(--modal-safe-max-height);
 }
 
 #menuModal .content-head {
@@ -1048,7 +1079,7 @@ button:focus {
     font-weight: bold;
 }
 
-.content-ei {
+.modal-container .content-ei {
     max-height: 85vh;
     overflow-y: auto;
 }
@@ -2095,6 +2126,52 @@ header button i {
     width: 95vw;
     max-height: 80vh;
     overflow-y: auto;
+}
+
+/* Safe-area height fallback for WebViews without min() */
+@supports (padding-top: env(safe-area-inset-top)) {
+    #endgameModal .content {
+        max-height: var(--modal-safe-max-height);
+    }
+
+    .modal-container .content-ei {
+        max-height: var(--modal-safe-max-height);
+    }
+
+    #combatPanel .content {
+        max-height: var(--modal-safe-max-height);
+    }
+
+    #defaultModal .content {
+        max-height: var(--modal-safe-max-height);
+    }
+
+    #forgeModal .content {
+        max-height: var(--modal-safe-max-height);
+    }
+}
+
+/* Preserve smaller modal caps when min() is supported */
+@supports (height: min(1px, 2px)) {
+    #endgameModal .content {
+        max-height: min(90vh, var(--modal-safe-max-height));
+    }
+
+    .modal-container .content-ei {
+        max-height: min(85vh, var(--modal-safe-max-height));
+    }
+
+    #combatPanel .content {
+        max-height: min(43rem, var(--modal-safe-max-height));
+    }
+
+    #defaultModal .content {
+        max-height: min(calc(100vh - 3rem), var(--modal-safe-max-height));
+    }
+
+    #forgeModal .content {
+        max-height: min(80vh, var(--modal-safe-max-height));
+    }
 }
 
 .forge-mode-toggle {

--- a/tests/modal-safe-area.test.js
+++ b/tests/modal-safe-area.test.js
@@ -1,0 +1,150 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const styleSource = fs.readFileSync(path.join(root, 'assets/css/style.css'), 'utf8');
+
+function ruleFor(selector) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = styleSource.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+    assert.ok(match, `missing CSS rule for ${selector}`);
+    return match[1];
+}
+
+function ruleAfter(marker, selector) {
+    const markerIndex = styleSource.indexOf(marker);
+    assert.notEqual(markerIndex, -1, `missing CSS marker ${marker}`);
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = styleSource.slice(markerIndex).match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+    assert.ok(match, `missing CSS rule for ${selector} after ${marker}`);
+    return match[1];
+}
+
+test('modal overlay stays inside every Android safe-area inset', () => {
+    const rule = ruleFor('.modal-container');
+    const safeAreaRule = ruleAfter('/* Safe-area-capable modal placement */', '.modal-container');
+
+    for (const edge of ['top', 'right', 'bottom', 'left']) {
+        assert.match(rule, new RegExp(`${edge}:\\s*0`));
+    }
+    assert.doesNotMatch(rule, /env\(/);
+    assert.match(safeAreaRule, /top:\s*var\(--safe-area-inset-top,\s*env\(safe-area-inset-top,\s*0px\)\)/);
+    assert.match(safeAreaRule, /right:\s*var\(--safe-area-inset-right,\s*env\(safe-area-inset-right,\s*0px\)\)/);
+    assert.match(safeAreaRule, /bottom:\s*var\(--safe-area-inset-bottom,\s*env\(safe-area-inset-bottom,\s*0px\)\)/);
+    assert.match(safeAreaRule, /left:\s*var\(--safe-area-inset-left,\s*env\(safe-area-inset-left,\s*0px\)\)/);
+    assert.match(rule, /width:\s*auto/);
+    assert.match(rule, /height:\s*auto/);
+});
+
+test('legacy browsers keep oversized modal content scrollable from the safe top edge', () => {
+    const containerRule = ruleFor('.modal-container');
+    const contentRule = ruleFor('.modal-container .content');
+
+    assert.match(containerRule, /justify-content:\s*flex-start/);
+    assert.match(containerRule, /overflow-y:\s*auto/);
+    assert.match(containerRule, /padding:\s*0\.5rem\s+0/);
+    assert.match(contentRule, /margin:\s*auto\s+0\.5rem/);
+});
+
+test('dynamic viewport units only override the legacy fallback when supported', () => {
+    assert.match(
+        styleSource,
+        /--modal-safe-max-height:\s*calc\(100vh\s*-\s*1rem\);[\s\S]*@supports\s*\(padding-top:\s*env\(safe-area-inset-top\)\)[\s\S]*--modal-safe-max-height:[^;]*100vh[^;]*env\(safe-area-inset-top,[^;]*env\(safe-area-inset-bottom,[^;]*;[\s\S]*@supports\s*\(height:\s*100dvh\)[\s\S]*--modal-safe-max-height:[^;]*100dvh/,
+    );
+});
+
+test('full-height modal content is capped to the safe viewport', () => {
+    assert.match(styleSource, /--modal-safe-max-height:\s*calc\(/);
+
+    for (const selector of [
+        '#equipmentInfo .content.equipment-info-content--with-compare',
+        '#inventory .content',
+        '#menuModal .content',
+    ]) {
+        assert.match(
+            ruleFor(selector),
+            /max-height:[^;]*var\(--modal-safe-max-height\)/,
+            `${selector} must stay above system bars`,
+        );
+    }
+
+    assert.match(
+        ruleAfter('/* Safe-area height fallback for WebViews without min() */', '#defaultModal .content'),
+        /max-height:\s*var\(--modal-safe-max-height\)/,
+        '#defaultModal .content must stay above system bars',
+    );
+});
+
+test('every modal content variant preserves the shared safe-height cap', () => {
+    assert.match(
+        ruleFor('.modal-container .content'),
+        /max-height:[^;]*var\(--modal-safe-max-height\)/,
+        '.modal-container .content must retain the shared safe-height cap',
+    );
+
+    const selectors = [
+        '#endgameModal .content',
+        '.modal-container .content-ei',
+        '#combatPanel .content',
+        '#forgeModal .content',
+    ];
+
+    for (const selector of selectors) {
+        assert.match(
+            ruleAfter('/* Safe-area height fallback for WebViews without min() */', selector),
+            /max-height:[^;]*var\(--modal-safe-max-height\)/,
+            `${selector} must retain the shared safe-height cap`,
+        );
+    }
+});
+
+test('existing smaller modal caps remain as old-WebView fallbacks', () => {
+    const legacyCaps = new Map([
+        ['#endgameModal .content', '90vh'],
+        ['.modal-container .content-ei', '85vh'],
+        ['#combatPanel .content', '43rem'],
+        ['#defaultModal .content', 'calc(100vh - 3rem)'],
+        ['#forgeModal .content', '80vh'],
+    ]);
+
+    for (const [selector, legacyCap] of legacyCaps) {
+        const escapedCap = legacyCap.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        assert.match(
+            ruleFor(selector),
+            new RegExp(`max-height:\\s*${escapedCap}`),
+            `${selector} must preserve its previous cap for old WebViews`,
+        );
+    }
+});
+
+test('env-capable WebViews without min use the safe-area cap', () => {
+    const fallbackMarker = '/* Safe-area height fallback for WebViews without min() */';
+    const enhancementMarker = '/* Preserve smaller modal caps when min() is supported */';
+    const fallbackIndex = styleSource.indexOf(fallbackMarker);
+    const enhancementIndex = styleSource.indexOf(enhancementMarker);
+
+    assert.notEqual(fallbackIndex, -1, 'missing intermediate-WebView safe-area fallback');
+    assert.notEqual(enhancementIndex, -1, 'missing min() enhancement block');
+    assert.ok(fallbackIndex < enhancementIndex, 'min() enhancements must follow the safe fallback');
+
+    for (const selector of [
+        '#endgameModal .content',
+        '.modal-container .content-ei',
+        '#combatPanel .content',
+        '#defaultModal .content',
+        '#forgeModal .content',
+    ]) {
+        assert.match(
+            ruleAfter(fallbackMarker, selector),
+            /max-height:\s*var\(--modal-safe-max-height\)/,
+            `${selector} must use the safe cap when env() is supported`,
+        );
+        assert.match(
+            ruleAfter(enhancementMarker, selector),
+            /max-height:\s*min\([^;]*var\(--modal-safe-max-height\)\)/,
+            `${selector} must preserve its smaller cap when min() is supported`,
+        );
+    }
+});


### PR DESCRIPTION
## Why

Tall modals could extend behind Android system bars because fixed modal overlays used the full viewport and their content was capped with `100vh`/`100dvh` without subtracting safe-area insets.

## Changes

- constrain fixed modal overlays to all four Android safe-area insets
- add a shared safe viewport height for tall modal content, with Chrome 62-compatible `100vh`/zero-inset fallbacks and gated `env()`/`100dvh` enhancements
- enforce the safe height and scrolling on all modal content while preserving smaller per-modal limits
- add regression coverage for overlay insets and full-height modal caps

## Issue

On Android devices, tall menus could cover the status bar at the top or be overlapped by the gesture/navigation area at the bottom.

## Testing

- `node --test tests/modal-safe-area.test.js`
- `node --test tests/*.test.js` (209 passed)
- syntax-checked every JavaScript file outside `node_modules` with `node --check`

## Verification

- simulated a 1280x480 Android landscape viewport with 40 px top, 18 px side, and 56 px bottom safe-area insets
- verified all 11 modal containers remained within the safe viewport
- verified the menu content scrolled from top to bottom and the final Subreddit button stayed above the bottom safe area
- visually inspected both initial and fully scrolled menu states
