### PR TITLE
feat: add Auto Mode settings shortcut

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1429,8 +1429,13 @@ header button i {
 }
 
 #auto-mode-btn,
+#auto-mode-settings-btn,
 #combat-auto-mode-btn {
     padding-right: 0.7rem;
+}
+
+#auto-mode-settings-btn i {
+    margin: 0;
 }
 
 #combat-auto-mode-btn {

--- a/assets/js/automode.js
+++ b/assets/js/automode.js
@@ -283,6 +283,7 @@ const autoClaim = () => {
 };
 
 const autoModeBtn = document.querySelector("#auto-mode-btn");
+const autoModeSettingsBtn = document.querySelector("#auto-mode-settings-btn");
 
 const updateAutoModeBtn = () => {
     const buttons = [
@@ -297,6 +298,9 @@ const updateAutoModeBtn = () => {
 };
 
 const updateAutoModeBtnVisibility = () => {
+    if (autoModeSettingsBtn) {
+        autoModeSettingsBtn.classList.toggle("hidden", !autoModeUnlocked);
+    }
     if (autoModeBtnVisible && autoModeUnlocked) {
         autoModeBtn.classList.remove("hidden");
     } else {
@@ -345,6 +349,15 @@ if (typeof window !== 'undefined') {
 autoModeBtn.addEventListener('click', function () {
     toggleAutoMode();
 });
+
+if (autoModeSettingsBtn) {
+    autoModeSettingsBtn.addEventListener('click', function () {
+        if (typeof openMenu !== 'function') return;
+        openMenu();
+        const settingsButton = document.querySelector('#auto-mode-settings');
+        if (settingsButton) settingsButton.click();
+    });
+}
 
 updateAutoModeBtnVisibility();
 updateAutoModeBtn();

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
                 <div>
                     <button id="dungeonActivity"></button>
                     <button id="auto-mode-btn" class="hidden" aria-label="Toggle auto mode"><i class="fas fa-play"></i></button>
+                    <button id="auto-mode-settings-btn" class="hidden"><i class="fas fa-sliders-h" aria-hidden="true"></i><span class="sr-only"><span data-i18n="auto-mode">Auto Mode</span> <span data-i18n="settings">Settings</span></span></button>
                 </div>
             </div>
             <div class="logBox primary-panel">

--- a/tests/auto-mode-combat-toggle.test.js
+++ b/tests/auto-mode-combat-toggle.test.js
@@ -94,6 +94,32 @@ test('combat Auto Mode button is compact and rendered with the attack controls',
     assert.doesNotMatch(combatSource, /class="combat-auto-mode-controls"/);
 });
 
+test('Auto Mode settings shortcut remains hidden while Auto Mode is locked', () => {
+    const dungeonButton = createButton();
+    const settingsShortcut = createButton();
+    const context = vm.createContext({
+        document: {
+            querySelector: (selector) => {
+                if (selector === '#auto-mode-btn') return dungeonButton;
+                if (selector === '#auto-mode-settings-btn') return settingsShortcut;
+                return null;
+            },
+        },
+        dungeon: { status: { paused: false } },
+        localStorage: {
+            getItem: () => null,
+            setItem() {},
+        },
+        sfxPause: { play() {} },
+        sfxUnpause: { play() {} },
+        window: {},
+    });
+
+    vm.runInContext(autoModeSource, context);
+
+    assert.equal(settingsShortcut.classList.contains('hidden'), true);
+});
+
 test('Auto Mode settings shortcut opens settings directly when the Auto button is hidden', () => {
     assert.match(indexSource, /<button id="auto-mode-settings-btn"[^>]*>[\s\S]*?<span data-i18n="auto-mode">Auto Mode<\/span> <span data-i18n="settings">Settings<\/span><\/span><\/button>/);
 

--- a/tests/auto-mode-combat-toggle.test.js
+++ b/tests/auto-mode-combat-toggle.test.js
@@ -7,6 +7,7 @@ const vm = require('node:vm');
 const root = path.resolve(__dirname, '..');
 const autoModeSource = fs.readFileSync(path.join(root, 'assets/js/automode.js'), 'utf8');
 const combatSource = fs.readFileSync(path.join(root, 'assets/js/combat.js'), 'utf8');
+const indexSource = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 
 const createButton = () => {
     const classes = new Set();
@@ -91,4 +92,54 @@ test('combat Auto Mode button is compact and rendered with the attack controls',
     assert.ok(autoModeControlIndex < specialAbilityIndex);
     assert.match(combatSource, /id="combat-auto-mode-btn"[\s\S]*<span class="sr-only"/);
     assert.doesNotMatch(combatSource, /class="combat-auto-mode-controls"/);
+});
+
+test('Auto Mode settings shortcut opens settings directly when the Auto button is hidden', () => {
+    assert.match(indexSource, /<button id="auto-mode-settings-btn"[^>]*>[\s\S]*?<span data-i18n="auto-mode">Auto Mode<\/span> <span data-i18n="settings">Settings<\/span><\/span><\/button>/);
+
+    const dungeonButton = createButton();
+    const settingsShortcut = createButton();
+    let shortcutClick = null;
+    let menuOpenCount = 0;
+    let settingsOpenCount = 0;
+    settingsShortcut.addEventListener = (event, callback) => {
+        if (event === 'click') shortcutClick = callback;
+    };
+
+    const storage = new Map([
+        ['autoMode', 'false'],
+        ['autoModeBtnVisible', 'false'],
+    ]);
+    const context = vm.createContext({
+        document: {
+            querySelector: (selector) => {
+                if (selector === '#auto-mode-btn') return dungeonButton;
+                if (selector === '#auto-mode-settings-btn') return settingsShortcut;
+                if (selector === '#auto-mode-settings') {
+                    return { click: () => settingsOpenCount++ };
+                }
+                return null;
+            },
+        },
+        dungeon: { status: { paused: false } },
+        localStorage: {
+            getItem: (key) => storage.has(key) ? storage.get(key) : null,
+            setItem: (key, value) => storage.set(key, String(value)),
+        },
+        openMenu: () => menuOpenCount++,
+        sfxPause: { play() {} },
+        sfxUnpause: { play() {} },
+        window: {},
+    });
+
+    vm.runInContext(autoModeSource, context);
+
+    assert.equal(dungeonButton.classList.contains('hidden'), true);
+    assert.equal(settingsShortcut.classList.contains('hidden'), false);
+    assert.equal(typeof shortcutClick, 'function');
+
+    shortcutClick();
+
+    assert.equal(menuOpenCount, 1);
+    assert.equal(settingsOpenCount, 1);
 });


### PR DESCRIPTION
## Why
Changing Auto Mode preferences currently requires navigating through the main menu.

## Changes
- Add a compact sliders shortcut beside the dungeon controls
- Show it for unlocked Auto Mode owners even when the Auto toggle itself is hidden
- Open the existing Auto Mode settings directly while preserving the existing pause and modal flow
- Build its accessible name from the existing translated Auto Mode and Settings labels

## Testing
- Added a regression test for direct shortcut navigation and visibility
- `node --test tests/auto-mode-combat-toggle.test.js`
- `node --test tests/*.test.js`

## Verification
- 204 tests pass
- Browser/CDP verified the shortcut opens `#auto-tab` in one click, hides the intermediate menu, and pauses exploration
- Visually checked the German UI at a mobile-sized viewport
- Independent review found no security concerns or logic errors