### PR TITLE
fix: return from Auto Mode shortcut settings

### DIFF
--- a/assets/js/automode.js
+++ b/assets/js/automode.js
@@ -285,6 +285,29 @@ const autoClaim = () => {
 const autoModeBtn = document.querySelector("#auto-mode-btn");
 const autoModeSettingsBtn = document.querySelector("#auto-mode-settings-btn");
 
+const closeAutoModeSettingsModal = (returnToMenu = true) => {
+    defaultModalElement.style.display = "none";
+    defaultModalElement.innerHTML = "";
+    if (returnToMenu) {
+        menuModalElement.style.display = "flex";
+        return;
+    }
+
+    continueExploring();
+    menuModalElement.style.display = "none";
+    menuModalElement.innerHTML = "";
+    const dimDungeon = document.querySelector('#dungeon-main');
+    const dimTitle = document.querySelector('#title-screen');
+    if (dimDungeon && window.getComputedStyle(dimDungeon).display !== 'none') {
+        dimDungeon.style.filter = "brightness(100%)";
+    }
+    if (dimTitle && window.getComputedStyle(dimTitle).display !== 'none') {
+        dimTitle.style.filter = "brightness(100%)";
+    }
+};
+
+window.closeAutoModeSettingsModal = closeAutoModeSettingsModal;
+
 const updateAutoModeBtn = () => {
     const buttons = [
         autoModeBtn,
@@ -355,8 +378,9 @@ if (autoModeSettingsBtn) {
     autoModeSettingsBtn.addEventListener('click', function () {
         if (typeof openMenu !== 'function') return;
         openMenu();
-        const settingsButton = document.querySelector('#auto-mode-settings');
-        if (settingsButton) settingsButton.click();
+        if (typeof window.renderAutoModeSettingsModal === 'function') {
+            window.renderAutoModeSettingsModal(false);
+        }
     });
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -864,7 +864,7 @@ function openMenu(isTitle = false) {
     };
 
     // Function to render the auto mode settings modal
-    window.renderAutoModeSettingsModal = function () {
+    window.renderAutoModeSettingsModal = function (returnToMenu = true) {
         sfxOpen.play();
         const autoSellLevelOptions = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
         const autoSellBelowLevelSelected = Number.isNaN(autoSellBelowLevel)
@@ -963,14 +963,9 @@ function openMenu(isTitle = false) {
         };
         autoLevelUpToggle.addEventListener('change', updateAutoLevelUpPriorityControls);
         updateAutoLevelUpPriorityControls();
-        const closeAutoModeModal = () => {
-            defaultModalElement.style.display = "none";
-            defaultModalElement.innerHTML = "";
-            menuModalElement.style.display = "flex";
-        };
         autoClose.onclick = function () {
             sfxDecline.play();
-            closeAutoModeModal();
+            closeAutoModeSettingsModal(returnToMenu);
         };
 
         if (!autoModeUnlocked) {
@@ -1017,7 +1012,7 @@ function openMenu(isTitle = false) {
             localStorage.setItem("autoIgnoreDoors", autoIgnoreDoors);
             updateAutoModeBtnVisibility();
             updateAutoModeBtn();
-            closeAutoModeModal();
+            closeAutoModeSettingsModal(returnToMenu);
         };
     };
 

--- a/tests/auto-mode-combat-toggle.test.js
+++ b/tests/auto-mode-combat-toggle.test.js
@@ -158,7 +158,7 @@ test('Auto Mode settings shortcut opens settings directly when the Auto button i
     const settingsShortcut = createButton();
     let shortcutClick = null;
     let menuOpenCount = 0;
-    let settingsOpenCount = 0;
+    const settingsOrigins = [];
     settingsShortcut.addEventListener = (event, callback) => {
         if (event === 'click') shortcutClick = callback;
     };
@@ -172,9 +172,6 @@ test('Auto Mode settings shortcut opens settings directly when the Auto button i
             querySelector: (selector) => {
                 if (selector === '#auto-mode-btn') return dungeonButton;
                 if (selector === '#auto-mode-settings-btn') return settingsShortcut;
-                if (selector === '#auto-mode-settings') {
-                    return { click: () => settingsOpenCount++ };
-                }
                 return null;
             },
         },
@@ -186,7 +183,9 @@ test('Auto Mode settings shortcut opens settings directly when the Auto button i
         openMenu: () => menuOpenCount++,
         sfxPause: { play() {} },
         sfxUnpause: { play() {} },
-        window: {},
+        window: {
+            renderAutoModeSettingsModal: (returnToMenu) => settingsOrigins.push(returnToMenu),
+        },
     });
 
     vm.runInContext(autoModeSource, context);
@@ -198,5 +197,52 @@ test('Auto Mode settings shortcut opens settings directly when the Auto button i
     shortcutClick();
 
     assert.equal(menuOpenCount, 1);
-    assert.equal(settingsOpenCount, 1);
+    assert.deepEqual(settingsOrigins, [false]);
+});
+
+test('closing Auto Mode settings opened from the shortcut returns to the game', () => {
+    const dungeonButton = createButton();
+    const settingsShortcut = createButton();
+    const defaultModalElement = { style: { display: 'flex' }, innerHTML: 'settings' };
+    const menuModalElement = { style: { display: 'none' }, innerHTML: 'menu' };
+    const dungeonElement = { style: { display: 'flex', filter: 'brightness(50%)' } };
+    const titleElement = { style: { display: 'none', filter: '' } };
+    let continueCount = 0;
+    const storage = new Map([
+        ['autoMode', 'false'],
+        ['autoModeBtnVisible', 'true'],
+    ]);
+    const context = vm.createContext({
+        defaultModalElement,
+        menuModalElement,
+        document: {
+            querySelector: (selector) => {
+                if (selector === '#auto-mode-btn') return dungeonButton;
+                if (selector === '#auto-mode-settings-btn') return settingsShortcut;
+                if (selector === '#dungeon-main') return dungeonElement;
+                if (selector === '#title-screen') return titleElement;
+                return null;
+            },
+        },
+        localStorage: {
+            getItem: (key) => storage.has(key) ? storage.get(key) : null,
+            setItem: (key, value) => storage.set(key, String(value)),
+        },
+        continueExploring: () => continueCount++,
+        sfxPause: { play() {} },
+        sfxUnpause: { play() {} },
+        window: {
+            getComputedStyle: (element) => element.style,
+        },
+    });
+
+    vm.runInContext(autoModeSource, context);
+    context.window.closeAutoModeSettingsModal(false);
+
+    assert.equal(defaultModalElement.style.display, 'none');
+    assert.equal(defaultModalElement.innerHTML, '');
+    assert.equal(menuModalElement.style.display, 'none');
+    assert.equal(menuModalElement.innerHTML, '');
+    assert.equal(dungeonElement.style.filter, 'brightness(100%)');
+    assert.equal(continueCount, 1);
 });


### PR DESCRIPTION
## Why
The Auto Mode settings shortcut opens the settings directly from the game. Applying or closing those settings incorrectly returned players to the regular menu.

## Changes
- Track whether Auto Mode settings were opened from the regular menu or the shortcut
- Return directly to the game for the shortcut path
- Preserve the existing return-to-menu behavior for the regular menu path
- Restore the game brightness and exploration state when returning directly

## Issue
Using Apply or the close button after entering through the shortcut opened the regular menu even though the player did not enter through it.

## Testing
- `node --test tests/auto-mode-combat-toggle.test.js`
- `node --test tests/*.test.js`

## Verification
- Verified in headless Chrome that shortcut -> Apply closes both modals and restores game brightness
- Verified that menu -> Auto Mode -> Apply still returns to the regular menu
- Verified no browser console errors